### PR TITLE
Fix missing OpenSSL require

### DIFF
--- a/lib/rbeapi/eapilib.rb
+++ b/lib/rbeapi/eapilib.rb
@@ -31,6 +31,7 @@
 #
 require 'net/http'
 require 'json'
+require 'openssl'
 
 require 'net_http_unix'
 


### PR DESCRIPTION
Before:

		[1] pry(main)> require 'rbeapi/client'
		=> true
		[2] pry(main)> node = Rbeapi::Client.connect_to('switch-001')
		NameError: uninitialized constant Rbeapi::Eapilib::HttpsEapiConnection::OpenSSL
		from /Users/brandt/.cache/rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/rbeapi-0.1.0/lib/rbeapi/eapilib.rb:325:in `initialize'

After:

		[1] pry(main)> require 'rbeapi/client'
		=> true
		[2] pry(main)> node = Rbeapi::Client.connect_to('switch-001')
		=> #<Rbeapi::Client::Node:0x007fb2e4ba2d10
		 @autorefresh=true,
		 @connection=
		  #<Rbeapi::Eapilib::HttpsEapiConnection:0x007fb2e4ba2dd8
		   @error=nil,
		...