### PR TITLE
Feature - generate RPMs and instructions for SWIX files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ Gemfile.lock
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# RPM stuff
+rpmbuild
+rpms
+*.spec

--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ and uploaded to RubyGems.
   rbeapi``
 * To install the latest development version from Github, simply clone the
   develop branch and run ``rake build``
+* To create an RPM, run ``rake rpm``
+* To generate a SWIX file for EOS with necessary dependencies, run
+  ``rake all_rpms`` then follow the ``swix create`` instructions at the end.
 
 
 # Contributing

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,12 @@ task :build do
     system "gem build rbeapi.gemspec"
 end
 
+task :rpm => :build do
+    system "cp rbeapi.spec.tmpl rbeapi.spec"
+    system "sed -i -e 's/^Version:.*/Version: #{Rbeapi::VERSION}/g' rbeapi.spec"
+    system 'rpmbuild --define "_topdir %(pwd)/rpmbuild" --define "_builddir %{_topdir}" --define "_rpmdir %(pwd)/rpms" --define "_srcrpmdir %{_rpmdir}" --define "_sourcedir  %(pwd)" --define "_specdir %(pwd)" -ba rbeapi.spec'
+end
+
 task :release => :build do
     system "gem push rbeapi-#{Rbeapi::VERSION}.gem"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,7 @@ task :rpm => :build do
     system "cp rbeapi.spec.tmpl rbeapi.spec"
     system "sed -i -e 's/^Version:.*/Version: #{Rbeapi::VERSION}/g' rbeapi.spec"
     system 'rpmbuild --define "_topdir %(pwd)/rpmbuild" --define "_builddir %{_topdir}" --define "_rpmdir %(pwd)/rpms" --define "_srcrpmdir %{_rpmdir}" --define "_sourcedir  %(pwd)" --define "_specdir %(pwd)" -ba rbeapi.spec'
+    system 'rpmbuild --define "enterprise 1" --define "_topdir %(pwd)/rpmbuild" --define "_builddir %{_topdir}" --define "_rpmdir %(pwd)/rpms" --define "_srcrpmdir %{_rpmdir}" --define "_sourcedir  %(pwd)" --define "_specdir %(pwd)" -ba rbeapi.spec'
 end
 
 task :release => :build do

--- a/Rakefile
+++ b/Rakefile
@@ -7,11 +7,52 @@ task :build do
     system "gem build rbeapi.gemspec"
 end
 
+RPM_OPTS = '--define "_topdir %(pwd)/rpmbuild" --define "_builddir %{_topdir}" --define "_rpmdir %(pwd)/rpms" --define "_srcrpmdir %{_rpmdir}" --define "_sourcedir  %(pwd)" --define "_specdir %(pwd)" -bb'
+desc "Generate regular and puppet-enterprise rbeapi RPMs for EOS"
 task :rpm => :build do
-    system "cp rbeapi.spec.tmpl rbeapi.spec"
-    system "sed -i -e 's/^Version:.*/Version: #{Rbeapi::VERSION}/g' rbeapi.spec"
-    system 'rpmbuild --define "_topdir %(pwd)/rpmbuild" --define "_builddir %{_topdir}" --define "_rpmdir %(pwd)/rpms" --define "_srcrpmdir %{_rpmdir}" --define "_sourcedir  %(pwd)" --define "_specdir %(pwd)" -ba rbeapi.spec'
-    system 'rpmbuild --define "enterprise 1" --define "_topdir %(pwd)/rpmbuild" --define "_builddir %{_topdir}" --define "_rpmdir %(pwd)/rpms" --define "_srcrpmdir %{_rpmdir}" --define "_sourcedir  %(pwd)" --define "_specdir %(pwd)" -ba rbeapi.spec'
+    system "sed -e 's/^Version:.*/Version: #{Rbeapi::VERSION}/g' rbeapi.spec.tmpl > rbeapi.spec"
+    system "rpmbuild #{RPM_OPTS} rbeapi.spec"
+    system "rpmbuild #{RPM_OPTS} --define 'enterprise 1' rbeapi.spec"
+    puts "RPMs are available in rpms/noarch/"
+end
+
+desc "Package the inifile gem in to regular and puppet-enterprise RPMs for EOS"
+task :inifile do
+    # Get the latest version info
+    INIFILE_VERSION = `wget -q  --output-document=- https://rubygems.org/gems/inifile/versions.atom | awk -e '/title>inifile/ {match($2, \"[0-9.]+\", a); print a[0]; exit}'`.strip
+    system "gem fetch inifile --version '=#{INIFILE_VERSION}'"
+    puts "Building rpm for inifile (#{INIFILE_VERSION})"
+    system "sed -e 's/^Version:.*/Version: #{INIFILE_VERSION}/g' gems/inifile/inifile.spec.tmpl > gems/inifile/inifile.spec"
+    system "rpmbuild #{RPM_OPTS} gems/inifile/inifile.spec"
+    system "rpmbuild #{RPM_OPTS} --define 'enterprise 1' gems/inifile/inifile.spec"
+    puts "RPMs are available in rpms/noarch/"
+end
+
+desc "Package the net_http_unix gem in to an RPM for EOS"
+task :net_http_unix do
+    # Get the latest version info
+    NET_HTTP_VERSION = `wget -q  --output-document=- https://rubygems.org/gems/net_http_unix/versions.atom | awk -e '/title>net_http_unix/ {match($2, \"[0-9.]+\", a); print a[0]; exit}'`.strip
+    system "gem fetch net_http_unix --version '=#{NET_HTTP_VERSION}'"
+    puts "Building rpm for net_http_unix (#{NET_HTTP_VERSION})"
+    system "sed -e 's/^Version:.*/Version: #{NET_HTTP_VERSION}/g' gems/net_http_unix/net_http_unix.spec.tmpl > gems/net_http_unix/net_http_unix.spec"
+    system "rpmbuild #{RPM_OPTS} gems/net_http_unix/net_http_unix.spec"
+    puts "RPMs are available in rpms/noarch/"
+end
+
+desc "Generate all RPM packages needed for an EOS SWIX"
+task :all_rpms => :build do
+    Rake::Task['rpm'].invoke
+    Rake::Task['inifile'].invoke
+    Rake::Task['net_http_unix'].invoke
+    puts "RPMs are available in rpms/noarch/"
+    puts "Copy the RPMs to an EOS device then run the 'swix create' command."
+    puts "  Example: cd /mnt/flash; swix create rbeapi-0.1.0-1.swix \\"
+    puts "           rubygem-rbeapi-0.1.0-1.eos4.noarch.rpm \\"
+    puts "           rubygem-inifile-3.0.0-1.eos4.noarch.rpm \\"
+    puts "           rubygem-net_http_unix-0.2.1-1.eos4.noarch.rpm"
+    puts "  For PE:: cd/mnt/flash; swix create pe-rbeapi-0.1.0-1.swix \\"
+    puts "           pe-rubygem-rbeapi-0.1.0-1.eos4.noarch.rpm \\"
+    puts "           pe-rubygem-inifile-3.0.0-1.eos4.noarch.rpm "
 end
 
 task :release => :build do

--- a/gems/README.rst
+++ b/gems/README.rst
@@ -1,0 +1,4 @@
+This directory includes subdirectories for rubygems required by rbeapi.  The
+packaging definitions, herein, are ONLY to be used when packaging for
+Arista EOS.   For all other platform, native platform packages or the
+'gem install' command should be used.

--- a/gems/inifile/.gitignore
+++ b/gems/inifile/.gitignore
@@ -1,0 +1,2 @@
+# ignore generated RPM .spec files
+*.spec

--- a/gems/inifile/README.rst
+++ b/gems/inifile/README.rst
@@ -1,0 +1,5 @@
+This directory contains packaging information to create a basic RPM of
+the inifile ruby gem for EOS.  Due to thenature of EOS, certain shortcuts
+were used instead of the more formal method:
+
+    gem2rpm --fetch inifile > inifile.spec

--- a/gems/inifile/inifile.spec.tmpl
+++ b/gems/inifile/inifile.spec.tmpl
@@ -1,0 +1,80 @@
+# -*- rpm-spec -*-
+%global gem_name inifile
+
+Name:		%{?enterprise:pe-}rubygem-%{gem_name}
+Version:	3.0.0
+Release:	1.eos4
+Summary:	INI file reader and writer
+
+Group:		Development/Languages
+License:    Unknown
+URL:		http://rubygems.org/gems/inifile
+Source0:	https://rubygems.org/gems/%{gem_name}-%{version}.gem
+
+%if 0%{?enterprise:1} == 1
+# Use these settings for Puppet Enterprise
+%global gem /opt/puppet/bin/gem
+Requires: pe-ruby
+Requires: pe-rubygems
+Provides: pe-rubygem(%{gem_name}) = %{version}
+Provides: pe-rubygem-%{gem_name} = %{version}
+%else
+# Use these settings for all other installs
+%global gem gem
+Requires: ruby(abi) = %{rubyabi}
+Provides: ruby(%{gem_name}) = %{version}-%{release}
+%endif
+
+BuildArch: noarch
+
+%description
+Although made popular by Windows, INI files can be used on any system thanks
+to their flexibility. They allow a program to store configuration data, which
+can then be easily parsed and changed. Two notable systems that use the INI 
+format are Samba and Trac.
+More information about INI files can be found on the [Wikipedia
+Page](http://en.wikipedia.org/wiki/INI_file).
+### Properties
+The basic element contained in an INI file is the property. Every property has 
+a name and a value, delimited by an equals sign *=*. The name appears to the 
+left of the equals sign and the value to the right.
+name=value
+### Sections
+Section declarations start with *[* and end with *]* as in `[section1]` and 
+`[section2]` shown in the example below. The section declaration marks the 
+beginning of a section. All properties after the section declaration will be
+associated with that section.
+### Comments
+All lines beginning with a semicolon *;* or a number sign *#* are considered
+to be comments. Comment lines are ignored when parsing INI files.
+### Example File Format
+A typical INI file might look like this:
+[section1]
+; some comment on section1
+var1 = foo
+var2 = doodle
+var3 = multiline values \
+are also possible
+[section2]
+# another comment
+var1 = baz
+var2 = shoodle.
+
+%prep
+%setup -q -D -T -n  .
+
+%install
+install %{SOURCE0} %{buildroot}/
+
+%files
+/%{gem_name}-%{version}.gem
+
+%post
+%{gem} install --local /%{gem_name}-%{version}.gem > /dev/null 2>&1
+
+%preun
+%{gem} uninstall %{gem_name} --version '= %{version}' > /dev/null 2>&1
+
+%changelog
+* Tue Mar 17 2015 Jere Julian - 3.0.0-1
+- Initial package loosely based off of gem2rpm output

--- a/gems/net_http_unix/.gitignore
+++ b/gems/net_http_unix/.gitignore
@@ -1,0 +1,2 @@
+# ignore generated RPM .spec files
+*.spec

--- a/gems/net_http_unix/README.rst
+++ b/gems/net_http_unix/README.rst
@@ -1,0 +1,5 @@
+This directory contains packaging information to create a basic RPM of
+the net_http_unix ruby gem for EOS.  Due to thenature of EOS, certain shortcuts
+were used instead of the more formal method:
+
+    gem2rpm --fetch net_http_unix > net_http_unix.spec

--- a/gems/net_http_unix/net_http_unix.spec.tmpl
+++ b/gems/net_http_unix/net_http_unix.spec.tmpl
@@ -1,0 +1,50 @@
+# -*- rpm-spec -*-
+%global gem_name net_http_unix
+
+Name:		%{?enterprise:pe-}rubygem-%{gem_name}
+Version:	0.2.1
+Release:	1.eos4
+Summary:	Wrapper around Net::HTTP with AF_UNIX support
+
+Group:		Development/Languages
+License:    Apache 2.0 
+URL:		http://github.com/puppetlabs/net_http_unix
+Source0:	https://rubygems.org/gems/%{gem_name}-%{version}.gem
+
+%if 0%{?enterprise:1} == 1
+# Use these settings for Puppet Enterprise
+%global gem /opt/puppet/bin/gem
+Requires: pe-ruby
+Requires: pe-rubygems
+Provides: pe-rubygem(%{gem_name}) = %{version}
+Provides: pe-rubygem-%{gem_name} = %{version}
+%else
+# Use these settings for all other installs
+%global gem gem
+Requires: ruby(abi) = %{rubyabi}
+Provides: ruby(%{gem_name}) = %{version}-%{release}
+%endif
+
+BuildArch: noarch
+
+%description
+Wrapper around Net::HTTP with AF_UNIX support.
+
+%prep
+%setup -q -D -T -n  .
+
+%install
+install %{SOURCE0} %{buildroot}/
+
+%files
+/%{gem_name}-%{version}.gem
+
+%post
+%{gem} install --local /%{gem_name}-%{version}.gem > /dev/null 2>&1
+
+%preun
+%{gem} uninstall %{gem_name} --version '= %{version}' > /dev/null 2>&1
+
+%changelog
+* Tue Mar 17 2015 Jere Julian - 3.0.0-1
+- Initial package loosely based off of gem2rpm output

--- a/rbeapi.spec.tmpl
+++ b/rbeapi.spec.tmpl
@@ -1,0 +1,65 @@
+# -*- rpm-spec -*-
+%global gem_name rbeapi
+
+Name:		rubygem-%{gem_name}
+Version:	REPLACEME
+Release:	1.eos4
+Summary:	Arista eAPI Ruby Library for the EOS command API
+
+Group:		Development/Languages
+License:    New BSD
+URL:		https://github.com/arista-eosplus/rbeapi
+Source0:	%{gem_name}-%{version}.gem
+
+#%%global gemdir %(ruby -rubygems -e 'puts Gem::dir' 2>/dev/null)
+%global gemdir /opt/puppet/lib/ruby/gems/1.9.1
+%global geminstdir %{gemdir}/gems/%{gemname}-%{version}
+#Requires: ruby(abi) = %{rubyabi}
+Requires: ruby(abi)
+Requires: ruby(rubygems)
+Requires: ruby
+Requires: rubygem(net_http_unix)
+Requires: rubygem(inifile)
+#Provides:       ruby(%{gem_name}) = %{version}-%{release}
+Provides:       rubygem(%{gem_name}) = %{version}
+
+BuildArch: noarch
+
+%description
+The Ruby Cliet for eAPI provides a native Ruby implementation for programming
+Arista EOS network devices using Ruby. The Ruby client provides the ability
+to build native applications in Ruby that can communicate with EOS either
+locally via Unix domain sockets (on-box) or remotely over a HTTP/S transport
+(off-box). It uses a standard INI-style configuration file to specifiy one or
+more connection profiles.
+
+The rbeapi implemenation also provides an API layer for building native Ruby
+objects that allow for configuration and state extraction of EOS nodes. The API
+layer provides a consistent implementation for working with EOS configuration
+resources. The implementation of the API layer is highly extensible and can be
+used as a foundation for building custom data models.
+
+The libray is freely provided to the open source community for building robust
+applications using Arista EOS eAPI. Support is provided as best effort through
+Github iusses.
+
+%prep
+%setup -q -D -T -n  .
+
+%install
+install %{SOURCE0} %{buildroot}/
+
+%files
+/%{gem_name}-%{version}.gem
+
+%post
+export PATH=/opt/puppet/bin:${PATH}
+gem install --local /%{gem_name}-%{version}.gem > /dev/null 2>&1
+
+%preun
+export PATH=/opt/puppet/bin:${PATH}
+gem uninstall %{gem_name} --version '= %{version}' > /dev/null 2>&1
+
+%changelog
+* Tue Mar 17 2015 Jere Julian - 0.1.0-1
+- Initial package

--- a/rbeapi.spec.tmpl
+++ b/rbeapi.spec.tmpl
@@ -1,7 +1,7 @@
 # -*- rpm-spec -*-
 %global gem_name rbeapi
 
-Name:		rubygem-%{gem_name}
+Name:		%{?enterprise:pe-}rubygem-%{gem_name}
 Version:	REPLACEME
 Release:	1.eos4
 Summary:	Arista eAPI Ruby Library for the EOS command API
@@ -11,17 +11,22 @@ License:    New BSD
 URL:		https://github.com/arista-eosplus/rbeapi
 Source0:	%{gem_name}-%{version}.gem
 
-#%%global gemdir %(ruby -rubygems -e 'puts Gem::dir' 2>/dev/null)
-%global gemdir /opt/puppet/lib/ruby/gems/1.9.1
-%global geminstdir %{gemdir}/gems/%{gemname}-%{version}
-#Requires: ruby(abi) = %{rubyabi}
-Requires: ruby(abi)
-Requires: ruby(rubygems)
-Requires: ruby
-Requires: rubygem(net_http_unix)
-Requires: rubygem(inifile)
-#Provides:       ruby(%{gem_name}) = %{version}-%{release}
-Provides:       rubygem(%{gem_name}) = %{version}
+%if 0%{?enterprise:1} == 1
+# Use these settings for Puppet Enterprise
+%global gem /opt/puppet/bin/gem
+Requires: pe-rubygems
+Requires: pe-ruby
+Requires: pe-rubygem(net-http-unix)
+Requires: pe-rubygem(inifile)
+Provides: pe-rubygem(%{gem_name}) = %{version}
+Provides: pe-rubygem-%{gem_name} = %{version}
+%else
+# Use these settings for all other installs
+%global gem gem
+Requires: ruby(abi) = %{rubyabi}
+Provides: ruby(%{gem_name}) = %{version}-%{release}
+%endif
+
 
 BuildArch: noarch
 
@@ -30,16 +35,16 @@ The Ruby Cliet for eAPI provides a native Ruby implementation for programming
 Arista EOS network devices using Ruby. The Ruby client provides the ability
 to build native applications in Ruby that can communicate with EOS either
 locally via Unix domain sockets (on-box) or remotely over a HTTP/S transport
-(off-box). It uses a standard INI-style configuration file to specifiy one or
+(off-box). It uses a standard INI-style configuration file to specify one or
 more connection profiles.
 
-The rbeapi implemenation also provides an API layer for building native Ruby
+The rbeapi implementation also provides an API layer for building native Ruby
 objects that allow for configuration and state extraction of EOS nodes. The API
 layer provides a consistent implementation for working with EOS configuration
 resources. The implementation of the API layer is highly extensible and can be
 used as a foundation for building custom data models.
 
-The libray is freely provided to the open source community for building robust
+The library is freely provided to the open source community for building robust
 applications using Arista EOS eAPI. Support is provided as best effort through
 Github iusses.
 
@@ -53,12 +58,10 @@ install %{SOURCE0} %{buildroot}/
 /%{gem_name}-%{version}.gem
 
 %post
-export PATH=/opt/puppet/bin:${PATH}
-gem install --local /%{gem_name}-%{version}.gem > /dev/null 2>&1
+%{gem} install --local /%{gem_name}-%{version}.gem > /dev/null 2>&1
 
 %preun
-export PATH=/opt/puppet/bin:${PATH}
-gem uninstall %{gem_name} --version '= %{version}' > /dev/null 2>&1
+%{gem} uninstall %{gem_name} --version '= %{version}' > /dev/null 2>&1
 
 %changelog
 * Tue Mar 17 2015 Jere Julian - 0.1.0-1


### PR DESCRIPTION
This includes packaging for net_http_unix and inifile rubygems ONLY to be used within an EOS swix.  Will generate an RPM for Ruby... open source (barename) and for the Ruby... provided with the pe-puppet extension (prefixed with pe-).