### PR TITLE
Fix RPM packaging for Ubuntu systems. Fixes #11

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,30 +13,39 @@ task :rpm => :build do
     system "sed -e 's/^Version:.*/Version: #{Rbeapi::VERSION}/g' rbeapi.spec.tmpl > rbeapi.spec"
     system "rpmbuild #{RPM_OPTS} rbeapi.spec"
     system "rpmbuild #{RPM_OPTS} --define 'enterprise 1' rbeapi.spec"
-    puts "RPMs are available in rpms/noarch/"
+    RPMS = `find rpms/noarch -name "*rbeapi*rpm"`
+    puts "\n################################################\n#"
+    puts "Created the following in rpms/noarch/\n#{RPMS}"
+    puts "#\n################################################\n\n"
 end
 
 desc "Package the inifile gem in to regular and puppet-enterprise RPMs for EOS"
 task :inifile do
     # Get the latest version info
-    INIFILE_VERSION = `wget -q  --output-document=- https://rubygems.org/gems/inifile/versions.atom | awk -e '/title>inifile/ {match($2, \"[0-9.]+\", a); print a[0]; exit}'`.strip
+    INIFILE_VERSION = `wget -q  --output-document=- https://rubygems.org/gems/inifile/versions.atom | awk '/title>inifile/ {match($2, \"[0-9.]+\", a); print a[0]; exit}'`.strip
     system "gem fetch inifile --version '=#{INIFILE_VERSION}'"
     puts "Building rpm for inifile (#{INIFILE_VERSION})"
     system "sed -e 's/^Version:.*/Version: #{INIFILE_VERSION}/g' gems/inifile/inifile.spec.tmpl > gems/inifile/inifile.spec"
     system "rpmbuild #{RPM_OPTS} gems/inifile/inifile.spec"
     system "rpmbuild #{RPM_OPTS} --define 'enterprise 1' gems/inifile/inifile.spec"
-    puts "RPMs are available in rpms/noarch/"
+    RPMS = `find rpms/noarch -name "*inifile*rpm"`
+    puts "\n################################################\n#"
+    puts "Created the following in rpms/noarch/\n#{RPMS}"
+    puts "#\n################################################\n\n"
 end
 
 desc "Package the net_http_unix gem in to an RPM for EOS"
 task :net_http_unix do
     # Get the latest version info
-    NET_HTTP_VERSION = `wget -q  --output-document=- https://rubygems.org/gems/net_http_unix/versions.atom | awk -e '/title>net_http_unix/ {match($2, \"[0-9.]+\", a); print a[0]; exit}'`.strip
+    NET_HTTP_VERSION = `wget -q  --output-document=- https://rubygems.org/gems/net_http_unix/versions.atom | awk '/title>net_http_unix/ {match($2, \"[0-9.]+\", a); print a[0]; exit}'`.strip
     system "gem fetch net_http_unix --version '=#{NET_HTTP_VERSION}'"
     puts "Building rpm for net_http_unix (#{NET_HTTP_VERSION})"
     system "sed -e 's/^Version:.*/Version: #{NET_HTTP_VERSION}/g' gems/net_http_unix/net_http_unix.spec.tmpl > gems/net_http_unix/net_http_unix.spec"
     system "rpmbuild #{RPM_OPTS} gems/net_http_unix/net_http_unix.spec"
-    puts "RPMs are available in rpms/noarch/"
+    RPMS = `find rpms/noarch -name "*net_http_unix*rpm"`
+    puts "\n################################################\n#"
+    puts "Created the following in rpms/noarch/\n#{RPMS}"
+    puts "#\n################################################\n\n"
 end
 
 desc "Generate all RPM packages needed for an EOS SWIX"
@@ -46,13 +55,13 @@ task :all_rpms => :build do
     Rake::Task['net_http_unix'].invoke
     puts "RPMs are available in rpms/noarch/"
     puts "Copy the RPMs to an EOS device then run the 'swix create' command."
-    puts "  Example: cd /mnt/flash; swix create rbeapi-0.1.0-1.swix \\"
-    puts "           rubygem-rbeapi-0.1.0-1.eos4.noarch.rpm \\"
-    puts "           rubygem-inifile-3.0.0-1.eos4.noarch.rpm \\"
-    puts "           rubygem-net_http_unix-0.2.1-1.eos4.noarch.rpm"
+    puts "  Example: cd /mnt/flash; swix create rbeapi-0.1.0-2.swix \\"
+    puts "           rubygem-rbeapi-0.1.0-2.eos4.noarch.rpm \\"
+    puts "           rubygem-inifile-3.0.0-2.eos4.noarch.rpm \\"
+    puts "           rubygem-net_http_unix-0.2.1-2.eos4.noarch.rpm"
     puts "  For PE:: cd/mnt/flash; swix create pe-rbeapi-0.1.0-1.swix \\"
-    puts "           pe-rubygem-rbeapi-0.1.0-1.eos4.noarch.rpm \\"
-    puts "           pe-rubygem-inifile-3.0.0-1.eos4.noarch.rpm "
+    puts "           pe-rubygem-rbeapi-0.1.0-2.eos4.noarch.rpm \\"
+    puts "           pe-rubygem-inifile-3.0.0-2.eos4.noarch.rpm "
 end
 
 task :release => :build do

--- a/gems/inifile/inifile.spec.tmpl
+++ b/gems/inifile/inifile.spec.tmpl
@@ -3,7 +3,7 @@
 
 Name:		%{?enterprise:pe-}rubygem-%{gem_name}
 Version:	3.0.0
-Release:	1.eos4
+Release:	2.eos4
 Summary:	INI file reader and writer
 
 Group:		Development/Languages
@@ -64,6 +64,7 @@ var2 = shoodle.
 %setup -q -D -T -n  .
 
 %install
+mkdir -p %{buildroot}
 install %{SOURCE0} %{buildroot}/
 
 %files
@@ -76,5 +77,8 @@ install %{SOURCE0} %{buildroot}/
 %{gem} uninstall %{gem_name} --version '= %{version}' > /dev/null 2>&1
 
 %changelog
+* Tue May 21 2015 Jere Julian - 3.0.0-2
+- Ubuntu requires we manually create the buildroot
+
 * Tue Mar 17 2015 Jere Julian - 3.0.0-1
 - Initial package loosely based off of gem2rpm output

--- a/gems/net_http_unix/net_http_unix.spec.tmpl
+++ b/gems/net_http_unix/net_http_unix.spec.tmpl
@@ -3,7 +3,7 @@
 
 Name:		%{?enterprise:pe-}rubygem-%{gem_name}
 Version:	0.2.1
-Release:	1.eos4
+Release:	2.eos4
 Summary:	Wrapper around Net::HTTP with AF_UNIX support
 
 Group:		Development/Languages
@@ -34,6 +34,7 @@ Wrapper around Net::HTTP with AF_UNIX support.
 %setup -q -D -T -n  .
 
 %install
+mkdir -p %{buildroot}
 install %{SOURCE0} %{buildroot}/
 
 %files
@@ -46,5 +47,8 @@ install %{SOURCE0} %{buildroot}/
 %{gem} uninstall %{gem_name} --version '= %{version}' > /dev/null 2>&1
 
 %changelog
-* Tue Mar 17 2015 Jere Julian - 3.0.0-1
+* Tue May 21 2015 Jere Julian - 0.2.1-2
+- Ubuntu requires we manually create the buildroot
+
+* Tue Mar 17 2015 Jere Julian - 0.2.1-1
 - Initial package loosely based off of gem2rpm output

--- a/rbeapi.spec.tmpl
+++ b/rbeapi.spec.tmpl
@@ -3,7 +3,7 @@
 
 Name:		%{?enterprise:pe-}rubygem-%{gem_name}
 Version:	REPLACEME
-Release:	1.eos4
+Release:	2.eos4
 Summary:	Arista eAPI Ruby Library for the EOS command API
 
 Group:		Development/Languages
@@ -52,6 +52,7 @@ Github iusses.
 %setup -q -D -T -n  .
 
 %install
+mkdir -p %{buildroot}
 install %{SOURCE0} %{buildroot}/
 
 %files
@@ -64,5 +65,8 @@ install %{SOURCE0} %{buildroot}/
 %{gem} uninstall %{gem_name} --version '= %{version}' > /dev/null 2>&1
 
 %changelog
+* Tue May 21 2015 Jere Julian - 0.1.0-2
+- Ubuntu requires we manually create the buildroot
+
 * Tue Mar 17 2015 Jere Julian - 0.1.0-1
 - Initial package


### PR DESCRIPTION
- Ubuntu 12 uses an older version of awk that does not support the -e
  option.
- Ubuntu rpmbuild does not auto-create the buildroot dir.
- Enhance final output from each RPM buld step in the Rakefile.