### PR TITLE
add "connection_unknown_host" section to eapi.conf

### DIFF
--- a/lib/rbeapi/client.rb
+++ b/lib/rbeapi/client.rb
@@ -235,8 +235,12 @@ module Rbeapi
       #   properities from the loaded config.  This method will return nil
       #   if the connection name is not found.
       def get_connection(name)
-        return nil unless sections.include? "connection:#{name}"
-        self["connection:#{name}"]
+        return self["connection:#{name}"] if sections.include? "connection:#{name}"
+
+        if (sections.include? "connection_unknown_host") && (name != "localhost") then
+          return merge(IniFile.new(:content => "[connection_unknown_host]\nhost: #{name}", :parameter => ":"))["connection_unknown_host"]
+        end
+        return nil
       end
 
       ##


### PR DESCRIPTION
Added optional section [connection_unknown_host] to eapi.conf , to avoid many [connection:] sections.

Will work as below.

```
[connection:veos-leaf001]
host: 192.168.101.52
username: kotetsu
password: kotetsu
transport: http

[connection_unknown_host]
username: kotetsu
password: kotetsu
transport: http
```

```ruby
node = Rbeapi::Client.connect_to('veos-leaf002')
```

`Config::get_connecton(name)` path through given name to host. 