### PR TITLE
Fixes #16 - Change port-channel members regex to anchor on word-boundary.

### DIFF
--- a/lib/rbeapi/api/interfaces.rb
+++ b/lib/rbeapi/api/interfaces.rb
@@ -622,7 +622,7 @@ module Rbeapi
         grpid = name.scan(/(?<=Port-Channel)\d+/)[0]
         command = "show port-channel #{grpid} all-ports"
         config = node.enable(command, format: 'text')
-        values = config.first[:result]['output'].scan(/Ethernet[\d\/]*/)
+        values = config.first[:result]['output'].scan(/\bEthernet[\d\/]*/)
         { members: values }
       end
       private :parse_members

--- a/spec/unit/rbeapi/api/interfaces/fixture_interfaces.text
+++ b/spec/unit/rbeapi/api/interfaces/fixture_interfaces.text
@@ -208,3 +208,12 @@ interface Vxlan1
    no vxlan learn-restrict vtep
    no vxlan vlan learn-restrict vtep
 !
+interface Port-Channel1
+   description mlag port-channel
+   switchport trunk allowed vlan 500-502
+   switchport mode trunk
+   port-channel lacp fallback static
+   port-channel lacp fallback timeout 30
+   mlag 1
+   spanning-tree portfast
+!

--- a/spec/unit/rbeapi/api/interfaces/portchannel_spec.rb
+++ b/spec/unit/rbeapi/api/interfaces/portchannel_spec.rb
@@ -20,11 +20,16 @@ describe Rbeapi::Api::PortchannelInterface do
   end
 
   describe '#get' do
+    before :each do
+      allow(subject.node).to receive(:enable)
+        .with(include('show port-channel'), format: 'text')
+        .and_return([{ result: { 'output' => "Port Channel Port-Channel1:\n  Active Ports: Ethernet1 PeerEthernet1 \n\n" } }])
+    end
     let(:resource) { subject.get('Port-Channel1') }
 
     let(:keys) do
-      [ :type, :shutdown, :description, :name, :members, :lacp_mode,
-        :minimum_links, :lacp_timeout, :lacp_fallback ]
+      [:type, :shutdown, :description, :name, :members, :lacp_mode,
+       :minimum_links, :lacp_timeout, :lacp_fallback]
     end
 
     it 'returns an ethernet resource as a hash' do
@@ -37,6 +42,14 @@ describe Rbeapi::Api::PortchannelInterface do
 
     it 'has all keys' do
       expect(resource.keys).to match_array(keys)
+    end
+
+    it 'does not return PeerEthernet members' do
+      expect(resource[:members]).to_not include 'PeerEthernet'
+    end
+
+    it 'returns 1 member' do
+      expect(resource[:members]).to contain_exactly('Ethernet1')
     end
   end
 
@@ -131,7 +144,4 @@ describe Rbeapi::Api::PortchannelInterface do
       expect(subject.set_shutdown('Port-Channel1', opts)).to be_truthy
     end
   end
-
-
 end
-


### PR DESCRIPTION
- Regex now anchors on a word-boundary
- Added 2 unit tests
- Fixup existing port-channel tests by mocking 'show port-channel <n>
  all-ports'