### PR TITLE
name path through if default connection is used

### DIFF
--- a/lib/rbeapi/client.rb
+++ b/lib/rbeapi/client.rb
@@ -101,6 +101,7 @@ module Rbeapi
       def connect_to(name)
         config = config_for(name)
         return nil unless config
+        config["host"] = name if config["host"] == "*"
         config = Rbeapi::Utils.transform_keys_to_symbols(config)
         connection = connect config
         Node.new(connection)


### PR DESCRIPTION
Thank you for add `[connection:*]` to eapi.conf syntax.

But now, if `[connection:*]` section is used,   `connect` method called with `"host"=>"*"` .
This PR fix it.

see. #18 
