### PR TITLE
Eliminate overloading value option in command_builder.

### DIFF
--- a/lib/rbeapi/api.rb
+++ b/lib/rbeapi/api.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -39,7 +39,7 @@ module Rbeapi
   module Api
     ##
     # The Entity class provides a base class implementation for building
-    # API modules.  The Entity class is typcially not instantiated directly
+    # API modules.  The Entity class is typically not instantiated directly
     # but serves as a super class with convenience methods used to
     # work with the node.
     class Entity
@@ -58,7 +58,7 @@ module Rbeapi
 
       ##
       # The Entity class provides a base class implementation for building
-      # API modules.  The Entity class is typcially not instantiated directly
+      # API modules.  The Entity class is typically not instantiated directly
       # but serves as a super class with convenience methods used to
       # work with the node.
       #
@@ -84,7 +84,7 @@ module Rbeapi
       # one exists) of the node's connection instance
       #
       # @return [Rbeapi::Eapilib::CommandError] An instance of CommandError
-      #   that can be used to futher evaluate the root cause of an error
+      #   that can be used to further evaluate the root cause of an error
       def error
         @node.connection.error
       end
@@ -133,29 +133,38 @@ module Rbeapi
       end
 
       ##
-      # command_builder builds the correct version of a command based on the
-      # configuration options.  If the value option is not provided then the
-      # no keyword is used to build the command.  If the default value is
-      # provided and set to true, then the default keyword is used.  If both
-      # options are provided, then the default option will take precedence.
+      # Method called to build the correct version of a command based on
+      # the modifier options.  If value option is set then it is appended
+      # to the command. If the enable option is false then the 'no'
+      # keyword is prefixed to the command.  If the default value is
+      # provided and set to true, then the default keyword is used.  If
+      # both options are provided, then default option takes precedence.
       #
-      # @return [String]
+      # @param [String, Array] :commands The commands to send to the node
+      #   over the API connection to configure the system
+      # @param [Hash] :opts the options for the command
+      #
+      # @option :opts  [String] :value Optional value that is
+      #   appended to the command if set.
+      #
+      # @option :opts  [Boolean] :enable Prefix the command with 'no'.
+      #   Default is true.
+      #
+      # @option :opts  [Boolean] :default Configure the command using
+      #   the default keyword. Default is false.
+      #
+      # @return [String] Returns built command string
       def command_builder(cmd, opts = {})
-        value = opts[:value]
+        enable = opts.fetch(:enable, true)
         default = opts.fetch(:default, false)
-        case default
-        when true then "default #{cmd}"
-        when false
-          case value
-          when nil, false then "no #{cmd}"
-          when true then cmd
-          else "#{cmd} #{value}"
-          end
-        end
+        cmd << " #{opts[:value]}" if opts[:value]
+        return "default #{cmd}" if default
+        return "no #{cmd}" unless enable
+        cmd
       end
 
       ##
-      # configure_interface sends the commands over eAPI to the desitnation
+      # configure_interface sends the commands over eAPI to the destination
       # node to configure a specific interface.
       #
       # @param [String] :name The interface name to apply the configuration

--- a/lib/rbeapi/api/dns.rb
+++ b/lib/rbeapi/api/dns.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,7 @@ module Rbeapi
       #     "domain_list": array<strings>
       #   }
       #
-      # @return [Hash]  A Ruby hash objec that provides the SNMP settings as
+      # @return [Hash]  A Ruby hash object that provides the SNMP settings as
       #   key / value pairs.
       def get
         response = {}
@@ -81,19 +81,13 @@ module Rbeapi
       #
       # @param [Hash] opts The configuration parameters
       # @option opts [string] :value The value to set the domain-name to
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       # @option opts [Boolean] :default The value should be set to default
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_domain_name(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        case default
-        when true
-          cmds = 'default ip domain-name'
-        when false
-          cmds = (value ? "ip domain-name #{value}" : 'no ip domain-name')
-        end
+        cmds = command_builder('ip domain-name', opts)
         configure(cmds)
       end
 
@@ -119,7 +113,7 @@ module Rbeapi
       # @option [Boolean] :default Configures the ip name-servers using the
       #   default keyword argument
       #
-      # @return [Boolean] returns true if the commands completed successfuly
+      # @return [Boolean] returns true if the commands completed successfully
       def set_name_servers(opts = {})
         value = opts[:value] || []
         default = opts[:default] || false
@@ -169,7 +163,7 @@ module Rbeapi
       # @option [Boolean] :default Configures the ip domain-list using the
       #   default keyword argument
       #
-      # @return [Boolean] returns true if the commands completed successfuly
+      # @return [Boolean] returns true if the commands completed successfully
       def set_domain_list(opts = {})
         value = opts[:value] || []
         default = opts[:default] || false

--- a/lib/rbeapi/api/dns.rb
+++ b/lib/rbeapi/api/dns.rb
@@ -93,7 +93,7 @@ module Rbeapi
 
       ##
       # set_name_servers configures the set of name servers that eos will use
-      # to resolve dns queries. If the value option is not provided, the
+      # to resolve dns queries. If the enable option is false, then the
       # name-server list will be configured using the no keyword.  If the
       # default option is specified, then the name server list will be
       # configured using the default keyword.  If both options are provided the
@@ -106,28 +106,30 @@ module Rbeapi
       #   no ip name-server
       #   default ip name-server
       #
-      # @option [Array] :value The set of name servers to configure on the
+      # @param [Hash] opts The configuration parameters
+      # @option opts [string] :value The set of name servers to configure on the
       #   node.  The list of name servers will be replace in the nodes running
       #   configuration by the list provided in value
-      #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       # @option [Boolean] :default Configures the ip name-servers using the
-      #   default keyword argument
+      #   default keyword argument. Default takes precedence over enable.
       #
       # @return [Boolean] returns true if the commands completed successfully
       def set_name_servers(opts = {})
-        value = opts[:value] || []
+        value = opts[:value]
+        enable = opts.fetch(:enable, true)
         default = opts[:default] || false
 
         case default
         when true
           cmds = 'default ip name-server'
         when false
-          cmds = []
-          parse_name_servers[:name_servers].each do |srv|
-            cmds << "no ip name-server #{srv}"
-          end
-          value.each do |srv|
-            cmds << "ip name-server #{srv}"
+          cmds = ['no ip name-server']
+          if enable
+            value.each do |srv|
+              cmds << "ip name-server #{srv}"
+            end
           end
         end
         configure cmds
@@ -143,8 +145,8 @@ module Rbeapi
 
       ##
       # set_domain_list configures the set of domain names to search when
-      # making dns queries for the FQDN.  If the value option is not provided,
-      # the domain-list will be configured using the no keyword.  If the
+      # making dns queries for the FQDN.  If the enable option is set to false,
+      # then the domain-list will be configured using the no keyword.  If the
       # default option is specified, then the domain list will be configured
       # using the default keyword.  If both options are provided the default
       # keyword option will take precedence.
@@ -165,19 +167,24 @@ module Rbeapi
       #
       # @return [Boolean] returns true if the commands completed successfully
       def set_domain_list(opts = {})
-        value = opts[:value] || []
+        value = opts[:value]
+        enable = opts.fetch(:enable, true)
         default = opts[:default] || false
 
+        cmds = []
         case default
         when true
-          cmds = 'default ip domain-list'
+          parse_domain_list[:domain_list].each do |name|
+            cmds << "default ip domain-list #{name}"
+          end
         when false
-          cmds = []
           parse_domain_list[:domain_list].each do |name|
             cmds << "no ip domain-list #{name}"
           end
-          value.each do |name|
-            cmds << "ip domain-list #{name}"
+          if enable
+            value.each do |name|
+              cmds << "ip domain-list #{name}"
+            end
           end
         end
         configure cmds

--- a/lib/rbeapi/api/interfaces.rb
+++ b/lib/rbeapi/api/interfaces.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -100,7 +100,7 @@ module Rbeapi
       ##
       # get returns the specified interface resource hash that represents the
       # node's current interface configuration.   The BaseInterface class
-      # provides all the set of attributres that are common to all interfaces
+      # provides all the set of attributes that are common to all interfaces
       # in EOS.  This method will return an interface type of generic
       #
       # @example
@@ -129,14 +129,14 @@ module Rbeapi
 
       ##
       # parse_description scans the provided configuration block and parses
-      # the description value if it exists in the cofiguration.  If the
+      # the description value if it exists in the configuration.  If the
       # description value is not configured, then the DEFALT_INTF_DESCRIPTION
-      # value is returned.  The hash returned by this method is inteded to be
+      # value is returned.  The hash returned by this method is intended to be
       # merged into the interface resource hash returned by the get method.
       #
       # @api private
       #
-      # @eturn [Hash<Symbol, Object>] resource hash attribute
+      # @return [Hash<Symbol, Object>] resource hash attribute
       def parse_description(config)
         mdata = /^\s{3}description\s(.+)$/.match(config)
         { description: mdata.nil? ? DEFAULT_INTF_DESCRIPTION : mdata[1] }
@@ -148,7 +148,7 @@ module Rbeapi
       # the shutdown value.  If the shutdown value is configured then true
       # is returned as its value otherwise false is returned.  The hash
       # returned by this method is intended to be merged into the interface
-      # ressource hash returned by the get method.
+      # resource hash returned by the get method.
       #
       # @api private
       #
@@ -171,7 +171,7 @@ module Rbeapi
       #   interface name must be the full interface identifier (ie Loopback,
       #   not Lo)
       #
-      # @return [Boolean] returns true if the command completed succesfully
+      # @return [Boolean] returns true if the command completed successfully
       def create(value)
         configure("interface #{value}")
       end
@@ -212,12 +212,11 @@ module Rbeapi
 
       ##
       # set_description configures the description value for the specified
-      # interface name in the nodes running configuration.  If the value is
-      # not provided in the opts keyword hash then the description value is
-      # negated using the no keyword.  If the default keyword is set to
-      # true, then the description value is defaulted using the default
-      # keyword.  The default keyword takes precedence over the value
-      # keyword if both are provided.
+      # interface name in the nodes running configuration.  If the enable
+      # keyword is false then the description value is negated using the no
+      # keyword.  If the default keyword is set to true, then the description
+      # value is defaulted using the default keyword.  The default keyword takes
+      # precedence over the enable keyword if both are provided.
       #
       # @eos_version 4.13.7M
       #
@@ -229,6 +228,9 @@ module Rbeapi
       # @option :opts [String] :value The value to configure the description
       #   to in the node's configuration.
       #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
       # @option :opts [Boolean] :default Configure the interface description
       #   using the default keyword
       #
@@ -239,14 +241,13 @@ module Rbeapi
       end
 
       ##
-      # set_shutdown configures the adminstrative state of the specified
-      # interface in the node.  If the value is true, then the interface
-      # is adminstratively disabled.  If the value is false, then the
-      # interface is adminstratively enabled.  If no value is provided, then
-      # the interface is configured with the no keyword which is equivalent
-      # to false.  If the default keyword is set to true, then the interface
-      # shutdown value is configured using the default keyword.  The default
-      # keyword takes precedence over the value keyword if both are provided.
+      # set_shutdown configures the administrative state of the specified
+      # interface in the node.  If the enable keyword is false, then the
+      # interface is administratively disabled.  If the enable keyword is
+      # true, then the interface is administratively enabled.  If the default
+      # keyword is set to true, then the interface shutdown value is configured
+      # using the default keyword.  The default keyword takes precedence
+      # over the enable keyword if both are provided.
       #
       # @eos_version 4.13.7M
       #
@@ -255,9 +256,9 @@ module Rbeapi
       #
       # @param [hash] :opts Optional keyword arguments
       #
-      # @option :opts [Boolean] :value True if the interface should be
-      #   administratively disabled or false if the interface should be
-      #   administratively enabled
+      # @option :opts [Boolean] :enable True if the interface should be
+      #   administratively enabled or false if the interface should be
+      #   administratively disabled. Default is true.
       #
       # @option :opts [Boolean] :default Configure the interface shutdown
       #   using the default keyword
@@ -279,8 +280,8 @@ module Rbeapi
       DEFAULT_FORCED = false
 
       ##
-      # get returns the specified Etherent interface resource hash that
-      # respresents the interface's current configuration in th e node.
+      # get returns the specified Ethernet interface resource hash that
+      # represents the interface's current configuration in the node.
       #
       # The resource hash returned contains the following information:
       #
@@ -288,11 +289,11 @@ module Rbeapi
       #   * type (string): will always be 'ethernet'
       #   * description (string): the interface description value
       #   * speed (string): the current speed setting for the interface speed
-      #   * forced (boolean): true if autonegotiation is disabled otherwise
+      #   * forced (boolean): true if auto negotiation is disabled otherwise
       #     false
       #   * sflow (boolean): true if sflow is enabled on the interface
       #     otherwise false
-      #   * flowcontrol_send (string): the inteface flowcontrol send value.
+      #   * flowcontrol_send (string): the interface flowcontrol send value.
       #     Valid values are 'on' or 'off'
       #   * flowconrol_receive (string): the interface flowcontrol receive
       #     value.  Valid values are 'on' or 'off'
@@ -411,7 +412,7 @@ module Rbeapi
 
       ##
       # set_speed configures the interface speed and negotiation values on the
-      # specified interface.  If the value option is not provide, the speed
+      # specified interface.  If the enable option is false the speed
       # setting is configured using the no keyword.  If the default options is
       # set to true, then the speed setting is configured using the default
       # keyword.  If both options are specified, the default keyword takes
@@ -427,7 +428,10 @@ module Rbeapi
       # @option [String] :value The value to configure the speed setting to in
       #   the nodes running configuration
       #
-      # @option [Boolean] :forced Specifies if autonegotiation should be
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
+      # @option [Boolean] :forced Specifies if auto negotiation should be
       #   enabled (true) or disabled (false)
       #
       # @option :opts [Boolean] :default Configures the sflow value on the
@@ -437,6 +441,7 @@ module Rbeapi
       def set_speed(name, opts = {})
         value = opts[:value]
         forced = opts.fetch(:forced, false)
+        enable = opts.fetch(:enable, true)
         default = opts.fetch(:default, false)
 
         forced = 'forced' if forced
@@ -447,19 +452,18 @@ module Rbeapi
         when true
           cmds << 'default speed'
         when false
-          cmds << value ? "speed #{forced} #{value}" : 'no speed'
+          cmds << enable ? "speed #{forced} #{value}" : 'no speed'
         end
         configure cmds
       end
 
       ##
       # set_sflow configures the administrative state of sflow on the
-      # interface.  Setting the value to true enables sflow on the interface
-      # and setting the value to false disables sflow on the interface.  If the
-      # value is not provided, the sflow state is negated using the no keyword.
+      # interface.  Setting the enable keyword to true enables sflow on the
+      # interface and setting enable to false disables sflow on the interface.
       # If the default keyword is set to true, then the sflow value is
       # defaulted using the default keyword.  The default keyword takes
-      # precedence over the value keyword
+      # precedence over the enable keyword
       #
       # @eos_version 4.13.7M
       #
@@ -468,38 +472,25 @@ module Rbeapi
       #
       # @param [Hash] :opts optional keyword arguments
       #
-      # @option :opts [Boolean] :value Enables  sflow if the value is true or
-      #   disables sflow on the interface if false
+      # @option :opts [Boolean] :enable Enables sflow if the value is true or
+      #   disables sflow on the interface if false. Default is true.
       #
       # @option :opts [Boolean] :default Configures the sflow value on the
       #   interface using the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_sflow(name, opts = {})
-        value = opts[:value]
-        default = opts.fetch(:default, false)
-
-        case default
-        when true
-          command = 'default sflow enable'
-        when false
-          case value
-          when true
-            command = 'sflow enable'
-          when false
-            command = 'no sflow enable'
-          end
-        end
-        configure_interface(name, command)
+        commands = command_builder('sflow enable', opts)
+        configure_interface(name, commands)
       end
 
       ##
       # set_flowcontrol configures the flowcontrol value either on or off for
       # the for the specified interface in the specified direction (either send
-      # or receive).  If the value is not provided then the configuration is
+      # or receive).  If the enable keyword is false then the configuration is
       # negated using the no keyword.  If the default keyword is set to true,
       # then the state value is defaulted using the default keyword.  The
-      # default keyword takes precedence over the value keyword
+      # default keyword takes precedence over the enable keyword
       #
       # @eos_version 4.13.7M
       #
@@ -513,6 +504,9 @@ module Rbeapi
       #
       # @option :opts [String] :value Specifies the value to configure the
       #   flowcontrol setting for.  Valid values include on or off
+      #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       #
       # @option :opts [Boolean] :default Configures the flowcontrol value on
       #   the interface using the default keyword
@@ -539,6 +533,9 @@ module Rbeapi
       # @option :opts [String] :value Specifies the value to configure the
       #   flowcontrol setting for.  Valid values include on or off
       #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
       # @option :opts [Boolean] :default Configures the flowcontrol value on
       #   the interface using the default keyword
       #
@@ -562,6 +559,9 @@ module Rbeapi
       #
       # @option :opts [String] :value Specifies the value to configure the
       #   flowcontrol setting for.  Valid values include on or off
+      #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       #
       # @option :opts [Boolean] :default Configures the flowcontrol value on
       #   the interface using the default keyword
@@ -622,7 +622,7 @@ module Rbeapi
 
       ##
       # parse_members scans the nodes running config and returns all of the
-      # ethernet members for the port-channel interface specified.  If the
+      # Ethernet members for the port-channel interface specified.  If the
       # port-channel interface has no members configured, then this method will
       # assign an empty array as the value for members.  The hash returned is
       # intended to be merged into the interface resource hash
@@ -673,7 +673,7 @@ module Rbeapi
       #
       # @api private
       #
-      # @param [String] :config The interface configuration blcok to extract
+      # @param [String] :config The interface configuration block to extract
       #   the minimum links value from
       #
       # @return [Hash<Symbol, Object>] resource hash attribute
@@ -685,7 +685,7 @@ module Rbeapi
 
       ##
       # parse_lacp_fallback scans the interface config block and returns the
-      # confiured value of the lacp fallback attribute.  If the value is not
+      # configured value of the lacp fallback attribute.  If the value is not
       # configured, then the method will return the value of
       # DEFAULT_LACP_FALLBACK.  The hash returned is intended to be merged into
       # the interface resource hash
@@ -722,11 +722,11 @@ module Rbeapi
 
       ##
       # set_minimum_links configures the minimum physical links up required to
-      # consider the logical portchannel interface operationally up.  If no
-      # value is provided then the minimum-links is configured using the no
-      # keyword argument.  If the default keyword argument is provided and set
-      # to true, the minimum-links value is defaulted using the default
-      # keyword.  The default keyword takes precedence over the value keyword
+      # consider the logical portchannel interface operationally up.  If the
+      # enable keyword is false then the minimum-links is configured using the
+      # no keyword argument.  If the default keyword argument is provided and
+      # set to true, the minimum-links value is defaulted using the default
+      # keyword.  The default keyword takes precedence over the enable keyword
       # argument if both are provided.
       #
       # @eos_version 4.13.7M
@@ -739,6 +739,9 @@ module Rbeapi
       # @option :opts [String, Integer] :value Specifies the value to
       #   configure the minimum-links to in the configuration.  Valid values
       #   are in the range of 1 to 16.
+      #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       #
       # @option :opts [Boolean] :default Configures the minimum links value on
       #   the interface using the default keyword
@@ -796,7 +799,7 @@ module Rbeapi
       # @param [String] :name The name of the port-channel interface to apply
       #   the configuration to.
       #
-      # @param [String] :member The name of the physical ethernet interface to
+      # @param [String] :member The name of the physical Ethernet interface to
       #   add to the logical port-channel interface.
       #
       # @return [Boolean] returns true if the command completed successfully
@@ -816,7 +819,7 @@ module Rbeapi
       # @param [String] :name The name of the port-channel interface to apply
       #   the configuration to.
       #
-      # @param [String] :member The name of the physical ethernet interface to
+      # @param [String] :member The name of the physical Ethernet interface to
       #   remove from the logical port-channel interface.
       #
       # @return [Boolean] returns true if the command completed successfully
@@ -859,11 +862,11 @@ module Rbeapi
 
       ##
       # set_lacp_fallback configures the lacp fallback mode for the
-      # port-channel interface.  If no value is provided, lacp fallback is
-      # configured using the no keyword argument.  If the default option is
+      # port-channel interface.  If the enable keyword is false, lacp fallback
+      # is configured using the no keyword argument.  If the default option is
       # specified and set to true, the lacp fallback value is configured using
       # the default keyword.  The default keyword takes precedence over the
-      # value keyword if both options are provided.
+      # enable keyword if both options are provided.
       #
       # @eos_version 4.13.7M
       #
@@ -876,23 +879,25 @@ module Rbeapi
       #   the port-channel lacp fallback.  Valid values are individual and
       #   static
       #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
       # @option :opts [Boolean] :default Configures the lacp fallback value on
       #   the interface using the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_lacp_fallback(name, opts = {})
-        opts[:value] = nil if opts[:value] == 'disabled'
         commands = command_builder('port-channel lacp fallback', opts)
         configure_interface(name, commands)
       end
 
       ##
-      # set_lacp_timeout configures the lacp fallback timeou for the
-      # port-channel interface.  If no value is provided, lacp fallback timeout
-      # is configured using the no keyword argument.  If the default option is
-      # specified and set to true, the lacp fallback timeout value is
+      # set_lacp_timeout configures the lacp fallback timeout for the
+      # port-channel interface.  If the enable keyword is false, lacp fallback
+      # timeout is configured using the no keyword argument.  If the default
+      # option is specified and set to true, the lacp fallback timeout value is
       # configured using the default keyword.  The default keyword takes
-      # precedence over the value keyword if both options are provided.
+      # precedence over the enable keyword if both options are provided.
       #
       # @eos_version 4.13.7M
       #
@@ -904,6 +909,9 @@ module Rbeapi
       # @option :opts [String] :value Specifies the value to configure for
       #   the port-channel lacp fallback timeout.  Valid values range from
       #   1 to 100 seconds
+      #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       #
       # @option :opts [Boolean] :default Configures the lacp fallback timeout
       #   value on the interface using the default keyword
@@ -931,7 +939,7 @@ module Rbeapi
       #
       #   * name: (String) The full interface name identifier
       #   * type: (String) 'vxlan'
-      #   * descripition: (String) The configured interface description
+      #   * description: (String) The configured interface description
       #   * shutdown: (Boolean) The admin state of the interface
       #   * source_interface: (String) The vxlan source-interface value
       #   * multicast_group: (String) The vxlan multicast-group value
@@ -960,7 +968,7 @@ module Rbeapi
 
       ##
       # parse_source_interface scans the interface config block and returns the
-      # value of the vxlan source-interace.  If the source-interface is not
+      # value of the vxlan source-interface.  If the source-interface is not
       # configured then the value of DEFAULT_SRC_INTF is used.  The hash
       # returned is intended to be merged into the interface resource hash
       #
@@ -1016,7 +1024,7 @@ module Rbeapi
       # parse_flood_list scans the interface config block and returns the list
       # of configured VTEPs that comprise the flood list.  If there are no
       # flood list values configured, the value will return DEFAULT_FLOOD_LIST.
-      # The returned value is intended to be merged into the inteface resource
+      # The returned value is intended to be merged into the interface resource
       # Hash.
       #
       # @api private
@@ -1034,7 +1042,7 @@ module Rbeapi
 
       ##
       # parse_vlans scans the interface config block and returns the set of
-      # configured vlan to vni mappings.  if there are no vlans configured, the
+      # configured vlan to vni mappings.  If there are no vlans configured, the
       # value will return an empty Hash
       #
       # @api private
@@ -1054,7 +1062,7 @@ module Rbeapi
 
       ##
       # Configures the vxlan source-interface to the specified value.  This
-      # parameter should be a the interface identifier of the interface to act
+      # parameter should be the interface identifier of the interface to act
       # as the source for all Vxlan traffic
       #
       # @param [String] :name The name of the interface to apply the
@@ -1063,12 +1071,14 @@ module Rbeapi
       # @param [Hash] :opt Optional keyword arguments
       #
       # @option :opts [String] :value Configures the vxlan source-interface to
-      #   the spcified value.  If no value is provided and the
-      #   default keyword is not specified then the value is negated
+      #   the specified value
+      #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       #
       # @option :opts [Boolean] :default Specifies whether or not the
       #   multicast-group command is configured as default.  The value of this
-      #   option has a higher precedence than :value
+      #   option has a higher precedence than :enable
       #
       # @return [Boolean] Returns true if the commands complete successfully
       def set_source_interface(name = 'Vxlan1', opts = {})
@@ -1077,7 +1087,7 @@ module Rbeapi
       end
 
       ##
-      # Configures the vxlan multcast-group flood address to the specified
+      # Configures the vxlan multicast-group flood address to the specified
       # value.  The value should be a valid multicast address
       #
       # @param [String] :name The name of the interface to apply the
@@ -1085,9 +1095,11 @@ module Rbeapi
       #
       # @param [Hash] :opt Optional keyword arguments
       #
-      # @option :opts [String] :value Configures the mutlicast-group flood
-      #   address to the specified value.  If no value is provided and the
-      #   default keyword is not specified then the value is negated
+      # @option :opts [String] :value Configures the multicast-group flood
+      #   address to the specified value.
+      #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       #
       # @option :opts [Boolean] :default Specifies whether or not the
       #   multicast-group command is configured as default.  The value of this
@@ -1101,7 +1113,7 @@ module Rbeapi
 
       ##
       # set_udp_port configures the Vxlan udp-port value in EOS for the
-      # specified interface name.  If the value option is not provided then the
+      # specified interface name.  If the enable keyword is false then the
       # no keyword is used to configure the value.  If the default option is
       # provided and set to true, then the default keyword is used.  If both
       # options are provided, the default keyword will take precedence.
@@ -1115,6 +1127,9 @@ module Rbeapi
       # @option :opts [String] :value Specifies the value to configure the
       #   udp-port setting to.  Valid values are in the range of 1024 to
       #   65535
+      #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       #
       # @option :opts [Boolean] :default Configures the udp-port value on
       #   the interface using the default keyword

--- a/lib/rbeapi/api/ipinterfaces.rb
+++ b/lib/rbeapi/api/ipinterfaces.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -132,7 +132,7 @@ module Rbeapi
       private :parse_mtu
 
       ##
-      # parse_helper_addresses scans the provided configuraiton block and
+      # parse_helper_addresses scans the provided configuration block and
       # extracts any configured IP helper address values.  The interface could
       # be configured with one or more helper addresses.  If no helper
       # addresses are configured, then an empty array is set in the return
@@ -194,12 +194,13 @@ module Rbeapi
       end
 
       ##
-      # set_address configures a logical IP interface with an address.  The
-      # address value must be in the form of A.B.C.D/E.  If no value is
-      # provided, then the interface address is negated using the config no
-      # keyword.  If the default option is set to true, then the ip address
-      # value is defaulted using the default keyword.  The default keyword has
-      # precedence over the value keyword if both options are specified
+      # set_address configures a logical IP interface with an address.
+      # The address value must be in the form of A.B.C.D/E.  If the enable
+      # keyword is false, then the interface address is negated using the
+      # config no keyword.  If the default option is set to true, then the
+      # ip address # value is defaulted using the default keyword.  The
+      # default keyword has precedence over the enable keyword if both
+      # options are specified
       #
       # @eos_version 4.13.7M
       #
@@ -218,30 +219,24 @@ module Rbeapi
       #   for the specified interface name.  The value must be in the form
       #   of A.B.C.D/E
       #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
       # @option :opts [Boolean] :default Configure the ip address value using
       #   the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_address(name, opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        cmds = ["interface #{name}"]
-        case default
-        when true
-          cmds << 'default ip address'
-        when false
-          cmds << (value.nil? ? 'no ip address' : "ip address #{value}")
-        end
-        configure cmds
+        cmds = command_builder('ip address', opts)
+        configure_interface(name, cmds)
       end
 
       ##
       # set_mtu configures the IP mtu value of the ip interface in the nodes
-      # configuration.  If the value is not provided, then the ip mtu value is
-      # configured using the no keyword.  If the default keywork option is
+      # configuration.  If the enable option is false, then the ip mtu value is
+      # configured using the no keyword.  If the default keyword option is
       # provided and set to true then the ip mtu value is configured using the
-      # default keyword.  The default keyword has precedence over the value
+      # default keyword.  The default keyword has precedence over the enable
       # keyword if both options are specified.
       #
       # @eos_version 4.13.7M
@@ -261,22 +256,16 @@ module Rbeapi
       #   the nodes configuration.  Valid values are in the range of 68 to 9214
       #   bytes.  The default is 1500 bytes
       #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
       # @option :opts [Boolean] :default Configure the ip mtu value using
       #   the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_mtu(name, opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        cmds = ["interface #{name}"]
-        case default
-        when true
-          cmds << 'default mtu'
-        when false
-          cmds << (value.nil? ? 'no mtu' : "mtu #{value}")
-        end
-        configure cmds
+        cmds = command_builder('mtu', opts)
+        configure_interface(name, cmds)
       end
 
       ##

--- a/lib/rbeapi/api/ipinterfaces.rb
+++ b/lib/rbeapi/api/ipinterfaces.rb
@@ -298,21 +298,17 @@ module Rbeapi
       #
       def set_helper_addresses(name, opts = {})
         value = opts[:value]
+        enable = opts.fetch(:enable, true)
         default = opts[:default] || false
 
-        cmds = ["interface #{name}"]
         case default
         when true
-          cmds << 'default ip helper-address'
+          cmds = 'default ip helper-address'
         when false
-          if value.nil?
-            cmds << 'no ip helper-address'
-          else
-            cmds << 'no ip helper-address'
-            value.each { |addr| cmds << "ip helper-address #{addr}" }
-          end
+          cmds = ['no ip helper-address']
+          value.each { |addr| cmds << "ip helper-address #{addr}" } if enable
         end
-        configure cmds
+        configure_interface(name, cmds)
       end
     end
   end

--- a/lib/rbeapi/api/logging.rb
+++ b/lib/rbeapi/api/logging.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -83,13 +83,11 @@ module Rbeapi
 
       ##
       # set_enable configures the global logging instance on the node as either
-      # enabled or disabled.  If the value is set to true then logging is
-      # globally enabled and if set to false, it is globally disabled.  If no
-      # value is specified, then the no keyword is used to configure the
-      # logging enable value.  If the default keyword is specified and set to
-      # true, then the configuration is defaulted using the default keyword.
-      # The default keyword option takes precedence over the value keyword if
-      # both options are specified.
+      # enabled or disabled.  If the enable keyword is set to true then logging
+      # is globally enabled and if set to false, it is globally disabled.  If
+      # the default keyword is specified and set to true, then the configuration
+      # is defaulted using the default keyword.  The default keyword option
+      # takes precedence over the enable keyword if both options are specified.
       #
       # @eos_version 4.13.7M
       #
@@ -100,23 +98,15 @@ module Rbeapi
       #
       # @param [Hash] :opts Optional keyword arguments
       #
-      # @option :opts [Boolean] :value Enables logging globally if value is true
-      #   or disabled logging glboally if value is false
+      # @option :opts [Boolean] :enable Enables logging globally if value is
+      #   true or disabled logging globally if value is false
       #
       # @option :opts [Boolean] :default Configure the ip address value using
       #   the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_enable(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        case default
-        when true
-          cmd = 'default logging on'
-        when false
-          cmd = value ? 'logging on' : 'no logging on'
-        end
+        cmd = command_builder('logging on', opts)
         configure cmd
       end
 

--- a/lib/rbeapi/api/mlag.rb
+++ b/lib/rbeapi/api/mlag.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,7 @@ module Rbeapi
 
       ##
       # get scans the current nodes configuration and returns the values as
-      # a Hash descriping the current state.
+      # a Hash describing the current state.
       #
       # The resource hash returned contains the following:
       #   * domain_id: (String) The MLAG domain-id value
@@ -169,7 +169,7 @@ module Rbeapi
       private :parse_shutdown
 
       ##
-      # parse_interfaces scans the global configuraiton and returns all of the
+      # parse_interfaces scans the global configuration and returns all of the
       # configured MLAG interfaces.  Each interface returns the configured MLAG
       # identifier for establishing a MLAG peer.  The return value is intended
       # to be merged into the resource Hash
@@ -193,10 +193,10 @@ module Rbeapi
 
       ##
       # set_domain_id configures the mlag domain-id value in the current nodes
-      # running configuration. If the value keyword is not provided, the
-      # domain-id is configured with the no keyword.  If the default keyword is
-      # provided, the configuration is defaulted using the default keyword.
-      # The default keyword takes precedence over the value keywork if both
+      # running configuration. If the enable keyword is false, the the
+      # domain-id is configured with the no keyword.  If the default keyword
+      # is provided, the configuration is defaulted using the default keyword.
+      # The default keyword takes precedence over the enable keyword if both
       # options are specified
       #
       # @eos_version 4.13.7M
@@ -209,34 +209,29 @@ module Rbeapi
       #
       # @param [Hash] :opts Optional keyword arguments
       #
-      # @option :opts [String] :value The value to configurue the mlag
+      # @option :opts [String] :value The value to configure the mlag
       #   domain-id to.
+      #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       #
       # @option :opts [Boolean] :default Configure the domain-id value using
       #   the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_domain_id(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        cmds = ['mlag configuration']
-        case default
-        when true
-          cmds << 'default domain-id'
-        when false
-          cmds << (value ? "domain-id #{value}" : 'no domain-id')
-        end
+        cmd = command_builder('domain-id', opts)
+        cmds = ['mlag configuration', cmd]
         configure(cmds)
       end
 
       ##
       # set_local_interface configures the mlag local-interface value in the
-      # current nodes running configuration. If the value keyword is not
-      # provided, the local-interface is configured with the no keyword.  If
+      # current nodes running configuration. If the enable keyword is false,
+      # the local-interface is configured with the no keyword.  If
       # the default keyword is provided, the configuration is defaulted using
       # the default keyword.  The default keyword takes precedence over the
-      # value keywork if both options are specified
+      # enable keyword if both options are specified
       #
       # @eos_version 4.13.7M
       #
@@ -248,34 +243,29 @@ module Rbeapi
       #
       # @param [Hash] :opts Optional keyword arguments
       #
-      # @option :opts [String] :value The value to configurue the mlag
+      # @option :opts [String] :value The value to configure the mlag
       #   local-interface to.  The local-interface accepts full interface
       #   identifiers and expects a Vlan interface
+      #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       #
       # @option :opts [Boolean] :default Configure the local-interface value
       #   using the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_local_interface(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        cmds = ['mlag configuration']
-        case default
-        when true
-          cmds << 'default local-interface'
-        when false
-          cmds << (value ? "local-interface #{value}" : 'no local-interface')
-        end
+        cmd = command_builder('local-interface', opts)
+        cmds = ['mlag configuration', cmd]
         configure(cmds)
       end
 
       ##
       # set_peer_link configures the mlag peer-link value in the current nodes
-      # running configuration. If the value keyword is not provided, the
+      # running configuration. If enable keyword is false, then the
       # peer-link is configured with the no keyword.  If the default keyword
       # is provided, the configuration is defaulted using the default keyword.
-      # The default keyword takes precedence over the value keywork if both
+      # The default keyword takes precedence over the enable keyword if both
       # options are specified
       #
       # @eos_version 4.13.7M
@@ -288,34 +278,29 @@ module Rbeapi
       #
       # @param [Hash] :opts Optional keyword arguments
       #
-      # @option :opts [String] :value The value to configurue the mlag
+      # @option :opts [String] :value The value to configure the mlag
       #   peer-link to.  The peer-link accepts full interface identifiers
-      #   and expects an Ethernet or Port-Channel  interface
+      #   and expects an Ethernet or Port-Channel interface
+      #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       #
       # @option :opts [Boolean] :default Configure the peer-link using the
       #   default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_peer_link(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        cmds = ['mlag configuration']
-        case default
-        when true
-          cmds << 'default peer-link'
-        when false
-          cmds << (value ? "peer-link #{value}" : 'no peer-link')
-        end
+        cmd = command_builder('peer-link', opts)
+        cmds = ['mlag configuration', cmd]
         configure(cmds)
       end
 
       ##
       # set_peer_address configures the mlag peer-address value in the current
-      # nodes running configuration. If the value keyword is not provided, the
+      # nodes running configuration. If the enable keyword is false, then the
       # peer-address is configured with the no keyword.  If the default keyword
       # is provided, the configuration is defaulted using the default keyword.
-      # The default keyword takes precedence over the value keywork if both
+      # The default keyword takes precedence over the enable keyword if both
       # options are specified
       #
       # @eos_version 4.13.7M
@@ -328,36 +313,30 @@ module Rbeapi
       #
       # @param [Hash] :opts Optional keyword arguments
       #
-      # @option :opts [String] :value The value to configurue the mlag
+      # @option :opts [String] :value The value to configure the mlag
       #   peer-address to.  The peer-address accepts an IP address in the form
       #   of A.B.C.D/E
+      #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       #
       # @option :opts [Boolean] :default Configure the peer-address using the
       #   default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_peer_address(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        cmds = ['mlag configuration']
-        case default
-        when true
-          cmds << 'default peer-address'
-        when false
-          cmds << (value ? "peer-address #{value}" : 'no peer-address')
-        end
+        cmd = command_builder('peer-address', opts)
+        cmds = ['mlag configuration', cmd]
         configure(cmds)
       end
 
       ##
       # set_shutdown configures the administrative state of the mlag process on
-      # the current node.  If the value is true, then mlag is enabled and if
-      # the value is false, then mlag is disabled.  If no value is provided,
-      # the shutdown command is configured using the no keyword argument. If
-      # the default keyword is provided, the configuration is defaulted using
+      # the current node.  If the enable keyword is true, then mlag is enabled
+      # and if the enable keyword is false, then mlag is disabled. If the
+      # default keyword is provided, the configuration is defaulted using
       # the default keyword. The default keyword takes precedence over the
-      # value keywork if both options are specified
+      # enable keyword if both options are specified
       #
       # @eos_version 4.13.7M
       #
@@ -369,34 +348,26 @@ module Rbeapi
       #
       # @param [Hash] :opts Optional keyword arguments
       #
-      # @option :opts [Boolean] :value Enables the mlag configuration if value
-      #   is true or disables the mlag configuration if value is false.
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       #
       # @option :opts [Boolean] :default Configure the shutdown value using the
       #   default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_shutdown(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        cmds = ['mlag configuration']
-        case default
-        when true
-          cmds << 'default shutdown'
-        when false
-          cmds << (value ? 'shutdown' : 'no shutdown')
-        end
+        cmd = command_builder('shutdown', opts)
+        cmds = ['mlag configuration', cmd]
         configure(cmds)
       end
 
       ##
       # set_mlag_id configures the mlag id on the interface in the nodes
-      # current running configuration.  If the value is not specified, then the
+      # current running configuration.  If the enable keyword is false, then the
       # interface mlag id is configured using the no keyword.  If the default
       # keyword is provided and set to true, the interface mlag id is
       # configured using the default keyword.  The default keyword takes
-      # precedence over the value keyword if both options are specified
+      # precedence over the enable keyword if both options are specified
       #
       # @eos_version 4.13.7M
       #
@@ -407,7 +378,7 @@ module Rbeapi
       #     default mlag
       #
       # @param [String] :name The full interface identifier of the interface
-      #   to confgure th mlag id for.
+      #   to configure th mlag id for.
       #
       # @param [Hash] :opts Optional keyword arguments
       #
@@ -415,22 +386,16 @@ module Rbeapi
       #   interface mlag to.  The mlag id should be in the valid range of 1 to
       #   2000
       #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
       # @option :opts [Boolean] :default Configure the mlag value using the
       #   default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_mlag_id(name, opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        cmds = ["interface #{name}"]
-        case default
-        when true
-          cmds << 'default mlag'
-        when false
-          cmds << (value ? "mlag #{value}" : 'no mlag')
-        end
-        configure(cmds)
+        cmd = command_builder('mlag', opts)
+        configure_interface(name, cmd)
       end
     end
   end

--- a/lib/rbeapi/api/ntp.rb
+++ b/lib/rbeapi/api/ntp.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -38,8 +38,8 @@ module Rbeapi
   # Api is module namesapce for working with the EOS command API
   module Api
     ##
-    # The Ntp class provides an intstance for working with the nodes
-    # NTP configuraiton.
+    # The Ntp class provides an instance for working with the nodes
+    # NTP configuration.
     class Ntp < Entity
       DEFAULT_SRC_INTF = ''
 
@@ -82,7 +82,7 @@ module Rbeapi
       # parse_servers scans the nodes configuration and parses the configured
       # ntp server host names and/or addresses.  This method will also return
       # the value of prefer.  If no servers are configured, the value will be
-      # set to an empty array.  The return hash is inteded to be merged into
+      # set to an empty array.  The return hash is intended to be merged into
       # the resource hash
       #
       # @api private
@@ -98,39 +98,34 @@ module Rbeapi
 
       ##
       # set_source_interface configures the ntp source value in the nodes
-      # running configuration.  If no value is provided in the options, then
+      # running configuration.  If the enable keyword is false, then
       # the ntp source is configured with the no keyword argument.  If the
       # default keyword argument is provided and set to true, the value is
       # configured used the default keyword.  The default keyword takes
-      # precedence over the value keyword if both optiosn are specified.
+      # precedence over the enable keyword if both options are specified.
       #
       # @eos_version 4.13.7M
       #
       # @commands
       #   ntp source <value>
       #   no ntp source
-      #   deafult ntp source
+      #   default ntp source
       #
       # @param [Hash] :opts Optional keyword arguments
       #
       # @option :opts [String] :value The value to configure the ntp source
       #   in the nodes configuration
       #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
       # @option :opts [Boolean] :default Configure the ntp source value using
       #   the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_source_interface(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        case default
-        when true
-          cmds = 'default ntp source'
-        when false
-          cmds = (value ? "ntp source #{value}" : 'no ntp source')
-        end
-        configure(cmds)
+        cmd = command_builder('ntp source', opts)
+        configure(cmd)
       end
 
       ##

--- a/lib/rbeapi/api/ospf.rb
+++ b/lib/rbeapi/api/ospf.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -52,7 +52,7 @@ module Rbeapi
       #     "areas": {
       #       <string>: array<string>
       #     },
-      #     "resdistribute"
+      #     "redistribute"
       #   }
       #
       # @return [Hash]  A Ruby hash object that provides the OSPF settings as
@@ -117,16 +117,8 @@ module Rbeapi
       end
 
       def set_router_id(pid, opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        cmds = ["router ospf #{pid}"]
-        case default
-        when true
-          cmds << 'default router-id'
-        when false
-          cmds << (value ? "router-id #{value}" : 'no router-id')
-        end
+        cmd = command_builder('router-id', opts)
+        cmds = ["router ospf #{pid}", cmd]
         configure cmds
       end
 
@@ -163,7 +155,7 @@ module Rbeapi
       #   values for.  This must be the full interface identifier.
       #
       # @return [nil, Hash<String, String>] A Ruby hash that represents the
-      #   MLAG interface confguration.  A nil object is returned if the
+      #   MLAG interface configuration.  A nil object is returned if the
       #   specified interface is not configured
       def get(name)
         config = get_block("interface #{name}")
@@ -187,7 +179,7 @@ module Rbeapi
       #   }
       #
       # @return [nil, Hash<String, String>] A Ruby hash that represents the
-      #   MLAG interface confguration.  A nil object is returned if no
+      #   MLAG interface configuration.  A nil object is returned if no
       #   interfaces are configured.
       def getall
         interfaces = config.scan(/(?<=interface\s)[Et|Po|Lo|Vl].+/)
@@ -199,18 +191,9 @@ module Rbeapi
 
       def set_network_type(name, opts = {})
         value = opts[:value]
-        default = opts[:default] || false
-
-        return false unless %w(nil point-to-point).include?(value)
-
-        cmds = ["interface #{name}"]
-        case default
-        when true
-          cmds << 'default ip ospf network'
-        when false
-          cmds << (value ? "ip ospf network #{value}" : 'no ip ospf netework')
-        end
-        configure(cmds)
+        return false unless [nil, 'point-to-point'].include?(value)
+        cmd = command_builder('ip ospf network', opts)
+        configure_interface(name, cmd)
       end
     end
   end

--- a/lib/rbeapi/api/radius.rb
+++ b/lib/rbeapi/api/radius.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -46,7 +46,7 @@ module Rbeapi
 
       # Regular expression to extract a radius server's attributes from the
       # running-configuration text.  The explicit [ ] spaces enable line
-      # wrappping and indentation with the /x flag.
+      # wrapping and indentation with the /x flag.
       SERVER_REGEXP = /radius-server[ ]host[ ](.*?)
                        (?:[ ]vrf[ ]([^\s]+))?
                        (?:[ ]auth-port[ ](\d+))?
@@ -62,7 +62,7 @@ module Rbeapi
       # method.
       #
       # The resource hash returned contains the following information:
-      #  * key: (String) the key either in plaintext or hashed format
+      #  * key: (String) the key either in plain text or hashed format
       #  * key_format: (Fixnum) e.g. 0 or 7
       #  * timeout: (Fixnum) seconds before the timeout period ends
       #  * retransmit: (Fixnum), e.g. 3, attempts after first timeout expiry.
@@ -81,7 +81,7 @@ module Rbeapi
       end
 
       ##
-      # parse_time scans the nodes current configuraiton and parse the
+      # parse_time scans the nodes current configuration and parse the
       # radius-server timeout value.  The timeout value is expected to always
       # be present in the config
       #
@@ -96,7 +96,7 @@ module Rbeapi
 
       ##
       # parse_retransmit scans the cnodes current configuration and parses the
-      # radius-server retransmit value.  the retransmist value is expected to
+      # radius-server retransmit value.  the retransmit value is expected to
       # always be present in the config
       #
       # @api private
@@ -134,7 +134,7 @@ module Rbeapi
       # The resource hash returned contains the following information:
       #  * hostname: hostname or ip address
       #  * vrf: (String) vrf name
-      #  * key: (String) the key either in plaintext or hashed format
+      #  * key: (String) the key either in plain text or hashed format
       #  * key_format: (Fixnum) e.g. 0 or 7
       #  * timeout: (Fixnum) seconds before the timeout period ends
       #  * retransmit: (Integer), e.g. 3, attempts after first timeout expiry.
@@ -164,8 +164,8 @@ module Rbeapi
       private :parse_servers
 
       ##
-      # set_global_key configures the global radius-server key.  If the value
-      # option is not specified, radius-server key is configured using the no
+      # set_global_key configures the global radius-server key.  If the enable
+      # option is false, radius-server key is configured using the no
       # keyword. If the default option is specified, radius-server key is
       # configured using the default keyword. If both options are specified,
       # the default keyword option takes precedence.
@@ -181,8 +181,11 @@ module Rbeapi
       #   in the nodes running configuration
       #
       # @option [Fixnum] :key_format The format of the key to be passed to the
-      #   nodes running configuration.  Valid values are 0 (cleartext) or 7
+      #   nodes running configuration.  Valid values are 0 (clear text) or 7
       #   (encrypted).  The default value is 0 if format is not provided.
+      #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       #
       # @option [Boolean] :default Configures the radius-server key using the
       #   default keyword argument
@@ -190,6 +193,7 @@ module Rbeapi
       # @return [Boolean] returns true if the commands complete successfully
       def set_global_key(opts = {})
         value = opts[:value]
+        enable = opts.fetch(:enable, true)
         key_format = opts[:key_format] || 0
         default = opts[:default] || false
 
@@ -197,7 +201,7 @@ module Rbeapi
         when true
           cmds = 'default radius-server key'
         when false
-          if value
+          if enable
             cmds = "radius-server key #{key_format} #{value}"
           else
             cmds = 'no radius-server key'
@@ -208,7 +212,7 @@ module Rbeapi
 
       ##
       # set_global_timeout configures the radius-server timeout value.  If the
-      # value # options is not specified, radius-server timeout is configured
+      # enable option is false, then radius-server timeout is configured
       # using the no keyword.  If the default option is specified, radius-server
       # timeout is configured using the default keyword.  If both options are
       # specified then the default keyword takes precedence.
@@ -224,30 +228,21 @@ module Rbeapi
       #   radius-server timeout value to.  This value should be in the range of
       #   1 to 1000
       #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
       # @option [Boolean] :default Configures the radius-server timeout value
       #   using the default keyword.
       #
       # @return [Boolean] returns true if the commands complete successfully
       def set_global_timeout(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        case default
-        when true
-          cmds = 'default radius-server timeout'
-        when false
-          if value
-            cmds = "radius-server timeout #{value}"
-          else
-            cmds = 'no radius-server timeout'
-          end
-        end
-        configure cmds
+        cmd = command_builder('radius-server timeout', opts)
+        configure cmd
       end
 
       ##
-      # set_global_retransmit configures the global radius-server restransmit
-      # value. If the value is not specified, the radius-server retransmist
+      # set_global_retransmit configures the global radius-server retransmit
+      # value. If the enable option  is false, then the radius-server retransmit
       # value is configured using the no keyword.  If the default option is
       # specified, the radius-server retransmit value is configured using the
       # default keyword. If both options are specified then the default keyword
@@ -258,31 +253,22 @@ module Rbeapi
       # @commands
       #   radius-server retransmit <value>
       #   no radius-server retransmit
-      #   default radius-server retrasmit
+      #   default radius-server retransmit
       #
-      # @option [String, Fixnum] :value The valu to set the global
+      # @option [String, Fixnum] :value The value to set the global
       #   radius-server retransmit value to.  This value should be in the range
       #   of 1 to 100
+      #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       #
       # @option [Boolean] :default Configures the radius-server retransmit
       #   value using the default keyword
       #
       # @return [Boolean] returns true if the commands complete successfully
       def set_global_retransmit(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        case default
-        when true
-          cmds = 'default radius-server retransmit'
-        when false
-          if value
-            cmds = "radius-server retransmit #{value}"
-          else
-            cmds = 'no radius-server retransmit'
-          end
-        end
-        configure cmds
+        cmd = command_builder('radius-server retransmit', opts)
+        configure cmd
       end
 
       ##

--- a/lib/rbeapi/api/snmp.rb
+++ b/lib/rbeapi/api/snmp.rb
@@ -367,8 +367,8 @@ module Rbeapi
 
       ##
       # set_community_acl configures the acl to apply to the specified
-      # community name.  If the value option is not specified, the acl is
-      # removed from the community name
+      # community name.  When enable is true, it will remove the
+      # the named community and then add the new acl entry.
       #
       # @eos_version 4.13.7M
       #
@@ -379,16 +379,27 @@ module Rbeapi
       # @param [String] :name The name of the snmp community to add to the
       #   nodes running configuration.
       #
-      # @option [String] :value The name of the acl to apply to the snmp
-      #   community in the nodes config
+      # @param [Hash] opts The configuration parameters
+      #
+      # @option opts [String] :value The name of the acl to apply to the snmp
+      #   community in the nodes config. If nil, then the community name
+      #   allows access to all objects.
+      # @option opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      # @option opts [Boolean] :default Configure the snmp community name
+      #   using the default keyword. Default takes precedence over enable.
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_community_acl(name, opts = {})
         value = opts[:value]
+        enable = opts.fetch(:enable, true)
+        default = opts.fetch(:default, false)
+        # Default is same as negate for this command
+        enable = default ? false : enable
         communities = parse_communities[:communities]
         access = communities[name][:access] if communities.include?(name)
-        cmds = ["no snmp-server community #{name}",
-                "snmp-server community #{name} #{access} #{value}"]
+        cmds = ["no snmp-server community #{name}"]
+        cmds << "snmp-server community #{name} #{access} #{value}" if enable
         configure cmds
       end
 

--- a/lib/rbeapi/api/snmp.rb
+++ b/lib/rbeapi/api/snmp.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -39,10 +39,8 @@ module Rbeapi
   module Api
     ##
     # The Snmp class provides a class implementation for working with the
-    # nodes SNMP conifguration entity.  This class presents an abstraction
+    # nodes SNMP configuration entity.  This class presents an abstraction
     # of the node's snmp configuration from the running config.
-    #
-    # rubocop:disable Metrics/ClassLength
     #
     # @eos_version 4.13.7M
     class Snmp < Entity
@@ -145,7 +143,7 @@ module Rbeapi
       ##
       # parse_communities scans the running config from the node and parses all
       # of the configure snmp community strings.  If there are no configured
-      # snmp community strings, the communitys value is set to an empty array.
+      # snmp community strings, the community value is set to an empty array.
       # The returned hash is intended to be merged into the global snmp
       # resource hash
       #
@@ -164,8 +162,8 @@ module Rbeapi
 
       ##
       # parse_notifications scans the running configuration and parses all of
-      # the snmp trap notificaitons configuration.  It is expected the trap
-      # configuration is in the running config.  The returned hash is intendd
+      # the snmp trap notifications configuration.  It is expected the trap
+      # configuration is in the running config.  The returned hash is intended
       # to be merged into the resource hash
       def parse_notifications
         traps = config.scan(/(default|no)?[ ]?snmp-server enable traps (.+)$/)
@@ -181,7 +179,7 @@ module Rbeapi
       private :parse_notifications
 
       ##
-      # set_notification configures the snmp trap notificaiton for the
+      # set_notification configures the snmp trap notification for the
       # specified trap.  The name option accepts the snmp trap name to
       # configure or the keyword all to globally enable or disable
       # notifications.  If the optional state argument is not provided then the
@@ -210,11 +208,10 @@ module Rbeapi
 
       ##
       # set_location updates the snmp location value in the nodes running
-      # configuration.  If the value is not provided in the opts Hash then
-      # the snmp location value is negated using the no keyword.  If the
-      # default keyword is set to true, then the snmp location value is
-      # defaulted using the default keyword.  The default parameter takes
-      # precedence over the value keyword.
+      # configuration.  If enable is false, then the snmp location value is
+      # negated using the no keyword.  If the default keyword is set to true,
+      # then the snmp location value is defaulted using the default keyword.
+      # The default parameter takes precedence over the enable keyword.
       #
       # @eos_version 4.13.7M
       #
@@ -227,34 +224,25 @@ module Rbeapi
       #
       # @option opts [string] :value The snmp location value to configure
       #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
       # @option opts [Boolean] :default Configure the snmp location value
       #   using the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_location(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        case default
-        when true
-          cmds = ['default snmp-server location']
-        when false
-          if value.nil?
-            cmds = 'no snmp-server location'
-          else
-            cmds = "snmp-server location #{value}"
-          end
-        end
-        configure(cmds)
+        cmd = command_builder('snmp-server location', opts)
+        configure(cmd)
       end
 
       ##
       # set_contact updates the snmp contact value in the nodes running
-      # configuration.  If the value is not provided in the opts Hash then
+      # configuration.  If enable is false in the opts Hash then
       # the snmp contact value is negated using the no keyword.  If the
       # default keyword is set to true, then the snmp contact value is
       # defaulted using the default keyword.  The default parameter takes
-      # precedence over the value keyword.
+      # precedence over the enable keyword.
       #
       # @eos_version 4.13.7M
       #
@@ -267,34 +255,25 @@ module Rbeapi
       #
       # @option opts [string] :value The snmp contact value to configure
       #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
       # @option opts [Boolean] :default Configures the snmp contact value
       #   using the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_contact(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        case default
-        when true
-          cmds = ['default snmp-server contact']
-        when false
-          if value.nil?
-            cmds = 'no snmp-server contact'
-          else
-            cmds = "snmp-server contact #{value}"
-          end
-        end
-        configure(cmds)
+        cmd = command_builder('snmp-server contact', opts)
+        configure(cmd)
       end
 
       ##
       # set_chassis_id updates the snmp chassis id value in the nodes
-      # running configuration.  If the value is not provided in the opts
+      # running configuration.  If enable is false in the opts
       # Hash then the snmp chassis id value is negated using the no
       # keyword.  If the default keyword is set to true, then the snmp
       # chassis id value is defaulted using the default keyword.  The default
-      # keyword takes precedence over the value keyword.
+      # keyword takes precedence over the enable keyword.
       #
       # @eos_version 4.13.7M
       #
@@ -307,34 +286,25 @@ module Rbeapi
       #
       # @option opts [string] :value The snmp chassis id value to configure
       #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
       # @option opts [Boolean] :default Configures the snmp chassis id value
       #   using the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_chassis_id(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        case default
-        when true
-          cmds = 'default snmp-server chassis-id'
-        when false
-          if value.nil?
-            cmds = 'no snmp-server chassis-id'
-          else
-            cmds = "snmp-server chassis-id #{value}"
-          end
-        end
-        configure(cmds)
+        cmd = command_builder('snmp-server chassis-id', opts)
+        configure(cmd)
       end
 
       ##
       # set_source_interface updates the snmp source interface value in the
-      # nodes running configuration.  If the value is not provided in the opts
+      # nodes running configuration.  If enable is false in the opts
       # Hash then the snmp source interface is negated using the no keyword.
-      # If the deafult keyword is set to true, then the snmp source interface
-      # value is defaulted using the default keyword.  The deafult keyword
-      # takes precedence over the value keyword.
+      # If the default keyword is set to true, then the snmp source interface
+      # value is defaulted using the default keyword.  The default keyword
+      # takes precedence over the enable keyword.
       #
       # @eos_version 4.13.7M
       #
@@ -348,25 +318,15 @@ module Rbeapi
       # @option opts [string] :value The snmp source interface value to
       #   configure.  This method will not ensure the interface is present
       #   in the configuration
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       # @option opts [Boolean] :default Configures the snmp source interface
       #   value using the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_source_interface(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        case default
-        when true
-          cmds = ['default snmp-server source-interface']
-        when false
-          if value.nil?
-            cmds = 'no snmp-server source-interface'
-          else
-            cmds = "snmp-server source-interface #{value}"
-          end
-        end
-        configure(cmds)
+        cmd = command_builder('snmp-server source-interface', opts)
+        configure(cmd)
       end
 
       ##

--- a/lib/rbeapi/api/stp.rb
+++ b/lib/rbeapi/api/stp.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -67,7 +67,7 @@ module Rbeapi
       ##
       # parse_mode scans the nodes running configuration and extracts the
       # value of the spanning-tree mode.  The spanning tree mode is
-      # expected to be always be avaliable in the running config.  The return
+      # expected to be always be available in the running config.  The return
       # value is intended to be merged into the stp resource hash
       #
       # @api private
@@ -90,7 +90,7 @@ module Rbeapi
       end
 
       ##
-      # interfaces rereturns a memoized instance of StpInterfaces for
+      # interfaces returns a memoized instance of StpInterfaces for
       # configuring individual stp interfaces
       #
       # @return [StpInterfaces] an instance of StpInterfaces class
@@ -102,10 +102,10 @@ module Rbeapi
 
       ##
       # set_mode configures the stp mode in the global nodes running
-      # configuration.  If the value option is not specified, then the stp
+      # configuration.  If the enable option is false, then the stp
       # mode is configured with the no keyword argument.  If the default option
       # is specified then the mode is configured with the default keyword
-      # argument.  The default keyword argument takes precedence over the value
+      # argument.  The default keyword argument takes precedence over the enable
       # option if both are provided
       #
       # @eos_version 4.13.7M
@@ -120,25 +120,16 @@ module Rbeapi
       # @option :opts [String] :value The value to configure the stp mode to
       #   in the nodes current running configuration
       #
-      # @option :opts [Boolean] :deafult Configure the stp mode value using
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
+      # @option :opts [Boolean] :default Configure the stp mode value using
       #   the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       #
       def set_mode(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        case default
-        when true
-          cmd = 'default spanning-tree mode'
-        when false
-          if value
-            cmd = "spanning-tree mode #{value}"
-          else
-            cmd = 'no spanning-tree mode'
-          end
-        end
+        cmd = command_builder('spanning-tree mode', opts)
         configure cmd
       end
     end
@@ -151,7 +142,7 @@ module Rbeapi
       DEFAULT_STP_PRIORITY = '32768'
 
       ##
-      # get returns the specified stp intstance config parsed from the nodes
+      # get returns the specified stp instance config parsed from the nodes
       # current running configuration.
       #
       # @example
@@ -207,7 +198,7 @@ module Rbeapi
       ##
       # parse_priority will scan the nodes current configuration and extract
       # the stp priority value for the given stp instance.  If the stp
-      # instance prioirity is not configured, the priority value will be set
+      # instance priority is not configured, the priority value will be set
       # using DEFAULT_STP_PRIORITY.  The returned hash is intended to be merged
       # into the resource hash
       #
@@ -238,18 +229,21 @@ module Rbeapi
       # @param [String] inst The MST instance to configure
       # @param [Hash] opts The configuration parameters for the priority
       # @option opts [string] :value The value to set the priority to
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       # @option opts [Boolean] :default The value should be set to default
       #
       # @return [Boolean] True if the commands succeed otherwise False
       def set_priority(inst, opts = {})
         value = opts[:value]
+        enable = opts.fetch(:enable, true)
         default = opts[:default] || false
 
         case default
         when true
           cmd = "default spanning-tree mst #{inst} priority"
         when false
-          if value
+          if enable
             cmd = "spanning-tree mst #{inst} priority #{value}"
           else
             cmd = "no spanning-tree mst #{inst} priority"
@@ -261,7 +255,7 @@ module Rbeapi
 
     ##
     # The StpInterfaces class provides a class instance for working with
-    # spanning-tree insterfaces in EOS
+    # spanning-tree interfaces in EOS
     #
     class StpInterfaces < Entity
       ##
@@ -365,25 +359,14 @@ module Rbeapi
       # @param [String] name The name of the interface to configure
       # @param [Hash] opts The configuration parameters for portfast
       # @option opts [Boolean] :value The value to set portfast
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       # @option opts [Boolean] :default The value should be set to default
       #
       # @return [Boolean] True if the commands succeed otherwise False
       def set_portfast(name, opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        cmds = ["interface #{name}"]
-        case default
-        when true
-          cmds << 'default spanning-tree portfast'
-        when false
-          if value
-            cmds << 'spanning-tree portfast'
-          else
-            cmds << 'no spanning-tree portfast'
-          end
-        end
-        configure(cmds)
+        cmd = command_builder('spanning-tree portfast', opts)
+        configure_interface(name, cmd)
       end
 
       ##

--- a/lib/rbeapi/api/stp.rb
+++ b/lib/rbeapi/api/stp.rb
@@ -375,21 +375,29 @@ module Rbeapi
       # @param [String] name The name of the interface to configure
       # @param [Hash] opts The configuration parameters for portfast type
       # @option opts [String] :value The value to set portfast type to.
+      #   The value must be set for calls to this method.
+      # @option opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       # @option opts [Boolean] :default The value should be set to default
       #
       # @return [Boolean] True if the commands succeed otherwise False
       def set_portfast_type(name, opts = {})
         value = opts[:value]
+        fail ArgumentError, 'value must be set' unless value
+        enable = opts.fetch(:enable, true)
         default = opts[:default] || false
 
-        cmds = ["interface #{name}"]
         case default
         when true
-          cmds << 'default spanning-tree portfast normal'
+          cmds = "default spanning-tree portfast #{value}"
         when false
-          cmds << "spanning-tree portfast #{value}"
+          if enable
+            cmds = "spanning-tree portfast #{value}"
+          else
+            cmds = "no spanning-tree portfast #{value}"
+          end
         end
-        configure(cmds)
+        configure_interface(name, cmds)
       end
 
       ##
@@ -398,25 +406,26 @@ module Rbeapi
       # @param [String] name The name of the interface to configure
       # @param [Hash] opts The configuration parameters for bpduguard
       # @option opts [Boolean] :value The value to set bpduguard
+      # @option opts [Boolean] :enable If false then the bpduguard is
+      #   disabled. If true then the bpduguard is enabled. Default is true.
       # @option opts [Boolean] :default The value should be set to default
       #
       # @return [Boolean] True if the commands succeed otherwise False
       def set_bpduguard(name, opts = {})
-        value = opts[:value]
+        enable = opts.fetch(:enable, true)
         default = opts[:default] || false
 
-        cmds = ["interface #{name}"]
         case default
         when true
-          cmds << 'default spanning-tree bpduguard'
+          cmds = 'default spanning-tree bpduguard'
         when false
-          if value
-            cmds << 'spanning-tree bpduguard enable'
+          if enable
+            cmds = 'spanning-tree bpduguard enable'
           else
-            cmds << 'spanning-tree bpduguard disable'
+            cmds = 'spanning-tree bpduguard disable'
           end
         end
-        configure(cmds)
+        configure_interface(name, cmds)
       end
     end
   end

--- a/lib/rbeapi/api/system.rb
+++ b/lib/rbeapi/api/system.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -49,7 +49,7 @@ module Rbeapi
       #     hostname: <string>
       #   }
       #
-      # @return [Hash]  A Ruby hash objec that provides the system settings as
+      # @return [Hash]  A Ruby hash object that provides the system settings as
       #   key/value pairs.
       def get
         response = {}
@@ -67,20 +67,14 @@ module Rbeapi
       #
       # @param [Hash] opts The configuration parameters
       # @option opts [string] :value The value to set the hostname to
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       # @option opts [Boolean] :default The value should be set to default
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_hostname(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        case default
-        when true
-          cmds = ['default hostname']
-        when false
-          cmds = (value.nil? ? 'no hostname' : "hostname #{value}")
-        end
-        configure(cmds)
+        cmd = command_builder('hostname', opts)
+        configure(cmd)
       end
     end
   end

--- a/lib/rbeapi/api/tacacs.rb
+++ b/lib/rbeapi/api/tacacs.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -46,7 +46,7 @@ module Rbeapi
 
       # Regular expression to extract a tacacs server's attributes from the
       # running-configuration text.  The explicit [ ] spaces enable line
-      # wrappping and indentation with the /x flag.
+      # wrapping and indentation with the /x flag.
       SERVER_REGEXP = /tacacs-server[ ]host[ ]([^\s]+)
                        (?:[ ](single-connection))?
                        (?:[ ]vrf[ ]([^\s]+))?
@@ -67,7 +67,7 @@ module Rbeapi
       #  * name: ('settings')
       #  * enable: (true | false) if tacacs functionality is enabled.  This is
       #    always true for EOS.
-      #  * key: (String) the key either in plaintext or hashed format
+      #  * key: (String) the key either in plain text or hashed format
       #  * key_format: (Integer) e.g. 0 or 7
       #  * timeout: (Integer) seconds before the timeout period ends
       #
@@ -130,7 +130,7 @@ module Rbeapi
       #
       #  * hostname: hostname or ip address, part of the identifier
       #  * port: (Fixnum) TCP port of the server, part of the identifier
-      #  * key: (String) the key either in plaintext or hashed format
+      #  * key: (String) the key either in plain text or hashed format
       #  * key_format: (Fixnum) e.g. 0 or 7
       #  * timeout: (Fixnum) seconds before the timeout period ends
       #  * multiplex: (Boolean) true when configured to make requests through a
@@ -161,7 +161,7 @@ module Rbeapi
       #
       # @option opts [String] :key ('070E234F1F5B4A') The key value
       #
-      # @option opts [Fixnum] :key_format (7) The key format, 0 for plaintext
+      # @option opts [Fixnum] :key_format (7) The key format, 0 for plain text
       #   and 7 for a hashed value.  7 will be assumed if this option is not
       #   provided.
       #
@@ -180,27 +180,18 @@ module Rbeapi
       # set_timeout configures the tacacs default timeout.  This method maps to
       # the `tacacs-server timeout` setting.
       #
-      # @option opts [Fixnum] :timeout (50) The timeout in seconds to
-      #   configure.
+      # @param [Hash] opts The configuration parameters
+      # @option opts [string] :value The value to set the timeout to
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      # @option opts [Boolean] :default The value should be set to default
       #
       # @api public
       #
       # @return [Boolean] true if no errors
       def set_global_timeout(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        case default
-        when true
-          cmds = 'default tacacs-server timeout'
-        when false
-          if value
-            cmds = "tacacs-server timeout #{value}"
-          else
-            cmds = 'no tacacs-server timeout'
-          end
-        end
-        configure cmds
+        cmd = command_builder('tacacs-server timeout', opts)
+        configure cmd
       end
 
       ##

--- a/lib/rbeapi/api/varp.rb
+++ b/lib/rbeapi/api/varp.rb
@@ -75,7 +75,7 @@ module Rbeapi
       #
       # @param [Hash] opts The configuration parameters
       # @option opts [string] :value The value to set the mac-address to
-      # @option :opts [Boolean] :enable If false then the command is
+      # @option opts [Boolean] :enable If false then the command is
       #   negated. Default is true.
       # @option opts [Boolean] :default The value should be set to default
       #
@@ -134,30 +134,39 @@ module Rbeapi
       end
 
       ##
-      # Creates a new MLAG interface with the specified mlag id
+      # The set_addresses method assigns one or more virtual IPv4 address
+      # to the specified VLAN interface. All existing addresses are
+      # removed before the ones in value are added.
       #
-      # @param [String] :name The name of the interface to create.  The
+      # @param [String] :name The name of the interface.  The
       #   name argument must be the full interface name.  Valid interfaces
-      #   are restricted to Port-Channel interfaces
-      # @param [String] :id The MLAG ID to configure for the specified
-      #   interface name
+      #   are restricted to VLAN interfaces
+      # @param [Hash] opts The configuration parameters
+      # @option opts [Array] :value Array of IPv4 addresses to add to
+      #   the virtual router.
+      # @option opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      # @option opts [Boolean] :default The value should be set to default
       #
       # @return [Boolean] True if the commands succeeds otherwise False
       def set_addresses(name, opts = {})
         value = opts[:value]
+        enable = opts.fetch(:enable, true)
         default = opts[:default] || false
 
         case default
         when true
-          return configure('default ip virtual-router address')
+          configure(["interface #{name}", 'default ip virtual-router address'])
         when false
           get(name)['addresses'].each do |addr|
             result = remove_address(name, addr)
             return result unless result
           end
-          value.each do |addr|
-            result = add_address(name, addr)
-            return result unless result
+          if enable
+            value.each do |addr|
+              result = add_address(name, addr)
+              return result unless result
+            end
           end
         end
         true

--- a/lib/rbeapi/api/varp.rb
+++ b/lib/rbeapi/api/varp.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -75,24 +75,14 @@ module Rbeapi
       #
       # @param [Hash] opts The configuration parameters
       # @option opts [string] :value The value to set the mac-address to
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
       # @option opts [Boolean] :default The value should be set to default
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_mac_address(opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        case default
-        when true
-          cmds = ['default ip virtual-router mac-address']
-        when false
-          if value
-            cmds = "ip virtual-router mac-address #{value}"
-          else
-            cmds = 'no ip virtual-router mac-address'
-          end
-        end
-        configure(cmds)
+        cmd = command_builder('ip virtual-router mac-address', opts)
+        configure(cmd)
       end
     end
 
@@ -113,7 +103,7 @@ module Rbeapi
       #   values for.  This must be the full interface identifier.
       #
       # @return [nil, Hash<String, String>] A Ruby hash that represents the
-      #   VARP interface confguration.  A nil object is returned if the
+      #   VARP interface configuration.  A nil object is returned if the
       #   specified interface is not configured
       def get(name)
         config = get_block("^interface #{name}")
@@ -133,7 +123,7 @@ module Rbeapi
       #   }
       #
       # @return [nil, Hash<String, String>] A Ruby hash that represents the
-      #   MLAG interface confguration.  A nil object is returned if no
+      #   MLAG interface configuration.  A nil object is returned if no
       #   interfaces are configured.
       def getall
         interfaces = config.scan(/(?<=^interface\s)(Vl.+)$/)
@@ -149,7 +139,7 @@ module Rbeapi
       # @param [String] :name The name of the interface to create.  The
       #   name argument must be the full interface name.  Valid interfaces
       #   are restricted to Port-Channel interfaces
-      # @param [String] :id The MLAG ID to confgure for the specified
+      # @param [String] :id The MLAG ID to configure for the specified
       #   interface name
       #
       # @return [Boolean] True if the commands succeeds otherwise False

--- a/lib/rbeapi/api/vlans.rb
+++ b/lib/rbeapi/api/vlans.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Arista Networks, Inc.
+# Copyright (c) 2014,2015, Arista Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -98,7 +98,7 @@ module Rbeapi
       ##
       # parse_name scans the provided configuration block and parses the
       # vlan name value.  The vlan name should always return a value
-      # from the running conifguration.  The return value is intended to
+      # from the running configuration.  The return value is intended to
       # be merged into the resource hash
       #
       # @api private
@@ -129,7 +129,7 @@ module Rbeapi
       # parse_trunk_groups scans the provided configuration block and parses
       # the trunk groups.  If no trunk groups are found in the nodes
       # running configuration then an empty array is returned as the value.
-      # The return hash is intedned to be merged into the resource hash.
+      # The return hash is intended to be merged into the resource hash.
       #
       # @api private
       #
@@ -199,11 +199,11 @@ module Rbeapi
 
       ##
       # set_name configures the name value for the specified vlan id in the
-      # nodes running configuration.  If the value is not provided in the
+      # nodes running configuration.  If enable is false in the
       # opts keyword Hash then the name value is negated using the no
       # keyword.  If the default keyword is set to true, then the name value
       # is defaulted using the default keyword.  The default keyword takes
-      # precedence over the value keyword
+      # precedence over the enable keyword
       #
       # @eos_version 4.13.7M
       #
@@ -211,7 +211,7 @@ module Rbeapi
       #   vlan <id>
       #     name <value>
       #     no name
-      #     defaul name
+      #     default name
       #
       # @param [String, Integer] :id The vlan id to apply the configuration
       #   to.  The id value should be in the valid range of 1 to 4094
@@ -222,31 +222,26 @@ module Rbeapi
       #   to in the node configuration.  The name parameter accepts a-z, 0-9
       #   and _.
       #
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
       # @option :opts [Boolean] :default Configure the vlan name value using
       #   the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
       def set_name(id, opts = {})
-        value = opts[:value]
-        default = opts[:default] || false
-
-        cmds = ["vlan #{id}"]
-        case default
-        when true
-          cmds << 'default name'
-        when false
-          cmds << (value.nil? ? 'no name' : "name #{value}")
-        end
+        cmd = command_builder('name', opts)
+        cmds = ["vlan #{id}", cmd]
         configure(cmds)
       end
 
       ##
       # set_state configures the state value for the specified vlan id in
-      # the nodes running configuration.  If the value is not provided in
+      # the nodes running configuration.  If enable is set to false in
       # the opts keyword Hash then the state value is negated using the no
       # keyword.  If the default keyword is set to true, then the state
       # value is defaulted using the default keyword.  The default keyword
-      # takes precedence over the value keyword
+      # takes precedence over the enable keyword
       #
       # @eos_version 4.13.7M
       #
@@ -265,7 +260,10 @@ module Rbeapi
       #   to in the node's configuration.  Accepted values are 'active' or
       #   'suspend'
       #
-      # @option :opts [Boolean] :deafult Configure the vlan state value using
+      # @option :opts [Boolean] :enable If false then the command is
+      #   negated. Default is true.
+      #
+      # @option :opts [Boolean] :default Configure the vlan state value using
       #   the default keyword
       #
       # @return [Boolean] returns true if the command completed successfully
@@ -274,19 +272,12 @@ module Rbeapi
       #   values
       def set_state(id, opts = {})
         value = opts[:value]
-        default = opts[:default] || false
-
         unless ['active', 'suspend', nil].include?(value)
           fail ArgumentError, 'state must be active, suspend or nil'
         end
 
-        cmds = ["vlan #{id}"]
-        case default
-        when true
-          cmds << 'default state'
-        when false
-          cmds << (value.nil? ? 'no state' : "state #{value}")
-        end
+        cmd = command_builder('state', opts)
+        cmds = ["vlan #{id}", cmd]
         configure(cmds)
       end
 

--- a/spec/system/api_ospf_interfaces_spec.rb
+++ b/spec/system/api_ospf_interfaces_spec.rb
@@ -57,5 +57,21 @@ describe Rbeapi::Api::OspfInterfaces do
         .to be_truthy
       expect(subject.get('Ethernet1')['network_type']).to eq('point-to-point')
     end
+
+    it 'negates the ospf interface type' do
+      expect(subject.set_network_type('Ethernet1', value: 'point-to-point'))
+        .to be_truthy
+      expect(subject.get('Ethernet1')['network_type']).to eq('point-to-point')
+      expect(subject.set_network_type('Ethernet1', enable: false)).to be_truthy
+      expect(subject.get('Ethernet1')['network_type']).to eq('broadcast')
+    end
+
+    it 'defaults the ospf interface type' do
+      expect(subject.set_network_type('Ethernet1', value: 'point-to-point'))
+        .to be_truthy
+      expect(subject.get('Ethernet1')['network_type']).to eq('point-to-point')
+      expect(subject.set_network_type('Ethernet1', default: true)).to be_truthy
+      expect(subject.get('Ethernet1')['network_type']).to eq('broadcast')
+    end
   end
 end

--- a/spec/system/api_ospf_spec.rb
+++ b/spec/system/api_ospf_spec.rb
@@ -53,6 +53,20 @@ describe Rbeapi::Api::Ospf do
       expect(subject.set_router_id('1', value: '1.1.1.1')).to be_truthy
       expect(subject.get('1')['router_id']).to eq('1.1.1.1')
     end
+
+    it 'negates the router id' do
+      expect(subject.set_router_id('1', value: '1.1.1.1')).to be_truthy
+      expect(subject.get('1')['router_id']).to eq('1.1.1.1')
+      expect(subject.set_router_id('1', enable: false)).to be_truthy
+      expect(subject.get('1')['router_id']).to be_empty
+    end
+
+    it 'defaults the router id' do
+      expect(subject.set_router_id('1', value: '1.1.1.1')).to be_truthy
+      expect(subject.get('1')['router_id']).to eq('1.1.1.1')
+      expect(subject.set_router_id('1', default: true)).to be_truthy
+      expect(subject.get('1')['router_id']).to be_empty
+    end
   end
 
   describe '#create' do

--- a/spec/system/api_varp_interfaces_spec.rb
+++ b/spec/system/api_varp_interfaces_spec.rb
@@ -65,5 +65,21 @@ describe Rbeapi::Api::VarpInterfaces do
         .to be_truthy
       expect(subject.get('Vlan100')['addresses']).not_to include('99.99.99.98')
     end
+
+    it 'negate the list of addresses' do
+      expect(subject.set_addresses('Vlan100', value: ['99.99.99.98']))
+        .to be_truthy
+      expect(subject.get('Vlan100')['addresses']).to include('99.99.99.98')
+      expect(subject.set_addresses('Vlan100', enable: false)).to be_truthy
+      expect(subject.get('Vlan100')['addresses']).to be_empty
+    end
+
+    it 'default the list of addresses' do
+      expect(subject.set_addresses('Vlan100', value: ['99.99.99.98']))
+        .to be_truthy
+      expect(subject.get('Vlan100')['addresses']).to include('99.99.99.98')
+      expect(subject.set_addresses('Vlan100', default: true)).to be_truthy
+      expect(subject.get('Vlan100')['addresses']).to be_empty
+    end
   end
 end

--- a/spec/system/rbeapi/api/dns_spec.rb
+++ b/spec/system/rbeapi/api/dns_spec.rb
@@ -27,6 +27,20 @@ describe Rbeapi::Api::Dns do
       expect(subject.set_domain_name(value: 'arista.com')).to be_truthy
       expect(subject.get[:domain_name]).to eq('arista.com')
     end
+
+    it 'negates the domain name' do
+      expect(subject.set_domain_name(value: 'arista.com')).to be_truthy
+      expect(subject.get[:domain_name]).to eq('arista.com')
+      expect(subject.set_domain_name(enable: false)).to be_truthy
+      expect(subject.get[:domain_name]).to be_empty
+    end
+
+    it 'defaults the domain name' do
+      expect(subject.set_domain_name(value: 'arista.com')).to be_truthy
+      expect(subject.get[:domain_name]).to eq('arista.com')
+      expect(subject.set_domain_name(default: true)).to be_truthy
+      expect(subject.get[:domain_name]).to be_empty
+    end
   end
 
   describe '#add_name_server' do

--- a/spec/system/rbeapi/api/dns_spec.rb
+++ b/spec/system/rbeapi/api/dns_spec.rb
@@ -43,6 +43,30 @@ describe Rbeapi::Api::Dns do
     end
   end
 
+  describe '#set_name_servers' do
+    let(:servers) {  %w(1.2.3.4 5.6.7.8 9.10.11.12) }
+
+    before { node.config('no ip name-server') }
+
+    it 'add all the servers to the name servers list' do
+      expect(subject.get[:name_servers]).to be_empty
+      expect(subject.set_name_servers(value: servers)).to be_truthy
+      expect(subject.get[:name_servers]).to eq(servers)
+    end
+
+    it 'negate the name servers list' do
+      expect(subject.get[:name_servers]).to be_empty
+      expect(subject.set_name_servers(enable: false)).to be_truthy
+      expect(subject.get[:name_servers]).to be_empty
+    end
+
+    it 'default the name servers list' do
+      expect(subject.get[:name_servers]).to be_empty
+      expect(subject.set_name_servers(default: true)).to be_truthy
+      expect(subject.get[:name_servers]).to be_empty
+    end
+  end
+
   describe '#add_name_server' do
     before do
       begin
@@ -66,6 +90,34 @@ describe Rbeapi::Api::Dns do
       expect(subject.get[:name_servers]).to include('1.2.3.4')
       expect(subject.remove_name_server('1.2.3.4')).to be_truthy
       expect(subject.get[:name_servers]).not_to include('1.2.3.4')
+    end
+  end
+
+  describe '#set_domain_list' do
+    let(:servers) {  %w(foo bar baz) }
+
+    before do
+      node.config(['no ip domain-list foo',
+                   'no ip domain-list bar',
+                   'no ip domain-list baz'])
+    end
+
+    it 'add all the servers to the name servers list' do
+      expect(subject.get[:domain_list]).to be_empty
+      expect(subject.set_domain_list(value: servers)).to be_truthy
+      expect(subject.get[:domain_list]).to eq(servers)
+    end
+
+    it 'negate the name servers list' do
+      expect(subject.get[:domain_list]).to be_empty
+      expect(subject.set_domain_list(enable: false)).to be_truthy
+      expect(subject.get[:domain_list]).to be_empty
+    end
+
+    it 'default the name servers list' do
+      expect(subject.get[:domain_list]).to be_empty
+      expect(subject.set_domain_list(default: true)).to be_truthy
+      expect(subject.get[:domain_list]).to be_empty
     end
   end
 

--- a/spec/system/rbeapi/api/interfaces_base_spec.rb
+++ b/spec/system/rbeapi/api/interfaces_base_spec.rb
@@ -79,14 +79,14 @@ describe Rbeapi::Api::Interfaces do
     it 'sets the shutdown value to true' do
       node.config(['interface Loopback0', 'no shutdown'])
       expect(subject.get('Loopback0')[:shutdown]).to be_falsy
-      expect(subject.set_shutdown('Loopback0', value: true)).to be_truthy
+      expect(subject.set_shutdown('Loopback0', enable: true)).to be_truthy
       expect(subject.get('Loopback0')[:shutdown]).to be_truthy
     end
 
     it 'sets the shutdown value to false' do
       node.config(['interface Loopback0', 'shutdown'])
       expect(subject.get('Loopback0')[:shutdown]).to be_truthy
-      expect(subject.set_shutdown('Loopback0', value: false)).to be_truthy
+      expect(subject.set_shutdown('Loopback0', enable: false)).to be_truthy
       expect(subject.get('Loopback0')[:shutdown]).to be_falsy
     end
   end

--- a/spec/system/rbeapi/api/interfaces_ethernet_spec.rb
+++ b/spec/system/rbeapi/api/interfaces_ethernet_spec.rb
@@ -73,14 +73,14 @@ describe Rbeapi::Api::Interfaces do
     it 'sets the shutdown value to true' do
       node.config(['interface Ethernet1', 'no shutdown'])
       expect(subject.get('Ethernet1')[:shutdown]).to be_falsy
-      expect(subject.set_shutdown('Ethernet1', value: true)).to be_truthy
+      expect(subject.set_shutdown('Ethernet1', enable: true)).to be_truthy
       expect(subject.get('Ethernet1')[:shutdown]).to be_truthy
     end
 
     it 'sets the shutdown value to false' do
       node.config(['interface Ethernet1', :shutdown])
       expect(subject.get('Ethernet1')[:shutdown]).to be_truthy
-      expect(subject.set_shutdown('Ethernet1', value: false)).to be_truthy
+      expect(subject.set_shutdown('Ethernet1', enable: false)).to be_truthy
       expect(subject.get('Ethernet1')[:shutdown]).to be_falsy
     end
   end
@@ -89,14 +89,14 @@ describe Rbeapi::Api::Interfaces do
     it 'sets the sflow value to true' do
       node.config(['interface Ethernet1', 'no sflow enable'])
       expect(subject.get('Ethernet1')[:sflow]).to be_falsy
-      expect(subject.set_sflow('Ethernet1', value: true)).to be_truthy
+      expect(subject.set_sflow('Ethernet1', enable: true)).to be_truthy
       expect(subject.get('Ethernet1')[:sflow]).to be_truthy
     end
 
     it 'sets the sflow value to false' do
       node.config(['interface Ethernet1', 'sflow enable'])
       expect(subject.get('Ethernet1')[:sflow]).to be_truthy
-      expect(subject.set_sflow('Ethernet1', value: false)).to be_truthy
+      expect(subject.set_sflow('Ethernet1', enable: false)).to be_truthy
       expect(subject.get('Ethernet1')[:sflow]).to be_falsy
     end
   end

--- a/spec/system/rbeapi/api/interfaces_portchannel_spec.rb
+++ b/spec/system/rbeapi/api/interfaces_portchannel_spec.rb
@@ -85,14 +85,14 @@ describe Rbeapi::Api::Interfaces do
     it 'sets the shutdown value to true' do
       node.config(['interface Port-Channel1', 'no shutdown'])
       expect(subject.get('Port-Channel1')[:shutdown]).to be_falsy
-      expect(subject.set_shutdown('Port-Channel1', value: true)).to be_truthy
+      expect(subject.set_shutdown('Port-Channel1', enable: true)).to be_truthy
       expect(subject.get('Port-Channel1')[:shutdown]).to be_truthy
     end
 
     it 'sets the shutdown value to false' do
-      node.config(['interface Port-Channel1', :shutdown])
+      node.config(['interface Port-Channel1', 'shutdown'])
       expect(subject.get('Port-Channel1')[:shutdown]).to be_truthy
-      expect(subject.set_shutdown('Port-Channel1', value: false)).to be_truthy
+      expect(subject.set_shutdown('Port-Channel1', enable: false)).to be_truthy
       expect(subject.get('Port-Channel1')[:shutdown]).to be_falsy
     end
   end
@@ -183,7 +183,7 @@ describe Rbeapi::Api::Interfaces do
       node.config(['interface Port-Channel1',
                    'port-channel lacp fallback static'])
       expect(subject.get('Port-Channel1')[:lacp_fallback]).to eq('static')
-      expect(subject.set_lacp_fallback('Port-Channel1', value: 'disabled'))
+      expect(subject.set_lacp_fallback('Port-Channel1', enable: false))
         .to be_truthy
       expect(subject.get('Port-Channel1')[:lacp_fallback]).to eq('disabled')
     end

--- a/spec/system/rbeapi/api/interfaces_vxlan_spec.rb
+++ b/spec/system/rbeapi/api/interfaces_vxlan_spec.rb
@@ -80,14 +80,14 @@ describe Rbeapi::Api::Interfaces do
     it 'sets the shutdown value to true' do
       node.config(['interface Vxlan1', 'no shutdown'])
       expect(subject.get('Vxlan1')[:shutdown]).to be_falsy
-      expect(subject.set_shutdown('Vxlan1', value: true)).to be_truthy
+      expect(subject.set_shutdown('Vxlan1', enable: true)).to be_truthy
       expect(subject.get('Vxlan1')[:shutdown]).to be_truthy
     end
 
     it 'sets the shutdown value to false' do
       node.config(['interface Vxlan1', 'shutdown'])
       expect(subject.get('Vxlan1')[:shutdown]).to be_truthy
-      expect(subject.set_shutdown('Vxlan1', value: false)).to be_truthy
+      expect(subject.set_shutdown('Vxlan1', enable: false)).to be_truthy
       expect(subject.get('Vxlan1')[:shutdown]).to be_falsy
     end
   end

--- a/spec/system/rbeapi/api/ipinterfaces_spec.rb
+++ b/spec/system/rbeapi/api/ipinterfaces_spec.rb
@@ -136,5 +136,19 @@ describe Rbeapi::Api::Ipinterfaces do
       expect(subject.get('Ethernet1')[:helper_addresses].sort)
         .to eq(helpers.sort)
     end
+
+    it 'negates the helper addresses on the interface' do
+      expect(subject.get('Ethernet1')[:helper_addresses]).to be_empty
+      expect(subject.set_helper_addresses('Ethernet1', enable: false))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:helper_addresses].sort).to be_empty
+    end
+
+    it 'default the helper addresses on the interface' do
+      expect(subject.get('Ethernet1')[:helper_addresses]).to be_empty
+      expect(subject.set_helper_addresses('Ethernet1', default: true))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:helper_addresses].sort).to be_empty
+    end
   end
 end

--- a/spec/system/rbeapi/api/ipinterfaces_spec.rb
+++ b/spec/system/rbeapi/api/ipinterfaces_spec.rb
@@ -76,6 +76,22 @@ describe Rbeapi::Api::Ipinterfaces do
         .to be_truthy
       expect(subject.get('Ethernet1')[:address]).to eq('77.99.99.99/24')
     end
+
+    it 'negates the address value' do
+      expect(subject.set_address('Ethernet1', value: '77.99.99.99/24'))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:address]).to eq('77.99.99.99/24')
+      expect(subject.set_address('Ethernet1', enable: false)).to be_truthy
+      expect(subject.get('Ethernet1')[:address]).to be_empty
+    end
+
+    it 'defaults the address value' do
+      expect(subject.set_address('Ethernet1', value: '77.99.99.99/24'))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:address]).to eq('77.99.99.99/24')
+      expect(subject.set_address('Ethernet1', default: true)).to be_truthy
+      expect(subject.get('Ethernet1')[:address]).to be_empty
+    end
   end
 
   describe '#set_mtu' do
@@ -88,6 +104,20 @@ describe Rbeapi::Api::Ipinterfaces do
       expect(subject.get('Ethernet1')[:mtu]).to eq('1500')
       expect(subject.set_mtu('Ethernet1', value: '2000')).to be_truthy
       expect(subject.get('Ethernet1')[:mtu]).to eq('2000')
+    end
+
+    it 'negates the mtu' do
+      expect(subject.set_mtu('Ethernet1', value: '2000')).to be_truthy
+      expect(subject.get('Ethernet1')[:mtu]).to eq('2000')
+      expect(subject.set_mtu('Ethernet1', enable: false)).to be_truthy
+      expect(subject.get('Ethernet1')[:mtu]).to eq('1500')
+    end
+
+    it 'defaults the mtu' do
+      expect(subject.set_mtu('Ethernet1', value: '2000')).to be_truthy
+      expect(subject.get('Ethernet1')[:mtu]).to eq('2000')
+      expect(subject.set_mtu('Ethernet1', default: true)).to be_truthy
+      expect(subject.get('Ethernet1')[:mtu]).to eq('1500')
     end
   end
 

--- a/spec/system/rbeapi/api/logging_spec.rb
+++ b/spec/system/rbeapi/api/logging_spec.rb
@@ -31,15 +31,31 @@ describe Rbeapi::Api::Logging do
     it 'configures global logging enabled' do
       node.config('no logging on')
       expect(subject.get[:enable]).to be_falsy
-      expect(subject.set_enable(value: true)).to be_truthy
+      expect(subject.set_enable(enable: true)).to be_truthy
       expect(subject.get[:enable]).to be_truthy
     end
 
     it 'configures global logging disabled' do
       node.config('logging on')
       expect(subject.get[:enable]).to be_truthy
-      expect(subject.set_enable(value: false)).to be_truthy
+      expect(subject.set_enable(enable: false)).to be_truthy
       expect(subject.get[:enable]).to be_falsy
+    end
+
+    it 'defaults the global logging' do
+      # Default is on
+
+      # Validate the on case
+      node.config('logging on')
+      expect(subject.get[:enable]).to be_truthy
+      expect(subject.set_enable(default: true)).to be_truthy
+      expect(subject.get[:enable]).to be_truthy
+
+      # Validate the off case
+      node.config('no logging on')
+      expect(subject.get[:enable]).to be_falsy
+      expect(subject.set_enable(default: true)).to be_truthy
+      expect(subject.get[:enable]).to be_truthy
     end
   end
 

--- a/spec/system/rbeapi/api/mlag_spec.rb
+++ b/spec/system/rbeapi/api/mlag_spec.rb
@@ -153,26 +153,30 @@ describe Rbeapi::Api::Mlag do
   describe '#set_mlag_id' do
     before do
       node.config(['default mlag configuration',
-                   'default interface Ethernet1'])
+                   'default interface Ethernet1',
+                   'default interface Port-Channel20',
+                   'interface Ethernet1',
+                   'channel-group 20 mode active',
+                   'interface port-channel 20',
+                   'mlag 20'])
     end
 
-    # XXX Not clear how to test this feature
-    # it 'configures the mlag id' do
-    #   expect(subject.get[:global][:mlag_id]).to be_nil
-    #   expect(subject.set_mlag_id('Ethernet1', value: '1000')).to be_truthy
-    #   expect(subject.get[:global][:mlag_id]).to eq('1000')
-    # end
-    # XXX Replace the mock calls below
-    it 'negates the mlag id' do
-      expect(node).to receive(:config).with(['interface Ethernet1',
-                                             'no mlag'])
-      expect(subject.set_mlag_id('Ethernet1', enable: false)).to be_truthy
+    it 'configure the mlag id' do
+      expect(subject.get[:interfaces]['Port-Channel20'][:mlag_id]).to eq(20)
+      expect(subject.set_mlag_id('Port-Channel20', value: '1000')).to be_truthy
+      expect(subject.get[:interfaces]['Port-Channel20'][:mlag_id]).to eq(1000)
     end
 
-    it 'defaults the mlag id' do
-      expect(node).to receive(:config).with(['interface Ethernet1',
-                                             'default mlag'])
-      expect(subject.set_mlag_id('Ethernet1', default: true)).to be_truthy
+    it 'negate the mlag id' do
+      expect(subject.get[:interfaces]['Port-Channel20'][:mlag_id]).to eq(20)
+      expect(subject.set_mlag_id('Port-Channel20', enable: false)).to be_truthy
+      expect(subject.get[:interfaces]['Port-Channel20']).to eq(nil)
+    end
+
+    it 'default the mlag id' do
+      expect(subject.get[:interfaces]['Port-Channel20'][:mlag_id]).to eq(20)
+      expect(subject.set_mlag_id('Port-Channel20', default: true)).to be_truthy
+      expect(subject.get[:interfaces]['Port-Channel20']).to eq(nil)
     end
   end
 end

--- a/spec/system/rbeapi/api/mlag_spec.rb
+++ b/spec/system/rbeapi/api/mlag_spec.rb
@@ -34,6 +34,20 @@ describe Rbeapi::Api::Mlag do
       expect(subject.set_domain_id(value: 'foo')).to be_truthy
       expect(subject.get[:global][:domain_id]).to eq('foo')
     end
+
+    it 'negates the mlag domain_id' do
+      expect(subject.set_domain_id(value: 'foo')).to be_truthy
+      expect(subject.get[:global][:domain_id]).to eq('foo')
+      expect(subject.set_domain_id(enable: false)).to be_truthy
+      expect(subject.get[:global][:domain_id]).to be_empty
+    end
+
+    it 'defaults the mlag domain_id' do
+      expect(subject.set_domain_id(value: 'foo')).to be_truthy
+      expect(subject.get[:global][:domain_id]).to eq('foo')
+      expect(subject.set_domain_id(default: true)).to be_truthy
+      expect(subject.get[:global][:domain_id]).to be_empty
+    end
   end
 
   describe '#set_local_interface' do
@@ -43,6 +57,20 @@ describe Rbeapi::Api::Mlag do
       expect(subject.get[:global][:local_interface]).to be_empty
       expect(subject.set_local_interface(value: 'Vlan4094')).to be_truthy
       expect(subject.get[:global][:local_interface]).to eq('Vlan4094')
+    end
+
+    it 'negates the local interface' do
+      expect(subject.set_local_interface(value: 'Vlan4094')).to be_truthy
+      expect(subject.get[:global][:local_interface]).to eq('Vlan4094')
+      expect(subject.set_local_interface(enable: false)).to be_truthy
+      expect(subject.get[:global][:local_interface]).to be_empty
+    end
+
+    it 'defaults the local interface' do
+      expect(subject.set_local_interface(value: 'Vlan4094')).to be_truthy
+      expect(subject.get[:global][:local_interface]).to eq('Vlan4094')
+      expect(subject.set_local_interface(default: true)).to be_truthy
+      expect(subject.get[:global][:local_interface]).to be_empty
     end
   end
 
@@ -57,6 +85,20 @@ describe Rbeapi::Api::Mlag do
       expect(subject.set_peer_link(value: 'Ethernet1')).to be_truthy
       expect(subject.get[:global][:peer_link]).to eq('Ethernet1')
     end
+
+    it 'negates the mlag peer link' do
+      expect(subject.set_peer_link(value: 'Ethernet1')).to be_truthy
+      expect(subject.get[:global][:peer_link]).to eq('Ethernet1')
+      expect(subject.set_peer_link(enable: false)).to be_truthy
+      expect(subject.get[:global][:peer_link]).to be_empty
+    end
+
+    it 'defaults the mlag peer link' do
+      expect(subject.set_peer_link(value: 'Ethernet1')).to be_truthy
+      expect(subject.get[:global][:peer_link]).to eq('Ethernet1')
+      expect(subject.set_peer_link(default: true)).to be_truthy
+      expect(subject.get[:global][:peer_link]).to be_empty
+    end
   end
 
   describe '#set_peer_address' do
@@ -70,21 +112,67 @@ describe Rbeapi::Api::Mlag do
       expect(subject.set_peer_address(value: '1.1.1.1')).to be_truthy
       expect(subject.get[:global][:peer_address]).to eq('1.1.1.1')
     end
+
+    it 'negates the mlag peer address' do
+      expect(subject.set_peer_address(value: '1.1.1.1')).to be_truthy
+      expect(subject.get[:global][:peer_address]).to eq('1.1.1.1')
+      expect(subject.set_peer_address(enable: false)).to be_truthy
+      expect(subject.get[:global][:peer_address]).to be_empty
+    end
+
+    it 'defaults the mlag peer address' do
+      expect(subject.set_peer_address(value: '1.1.1.1')).to be_truthy
+      expect(subject.get[:global][:peer_address]).to eq('1.1.1.1')
+      expect(subject.set_peer_address(default: true)).to be_truthy
+      expect(subject.get[:global][:peer_address]).to be_empty
+    end
   end
 
   describe '#set_shutdown' do
     it 'configures mlag to be enabled' do
       node.config(['mlag configuration', 'shutdown'])
       expect(subject.get[:global][:shutdown]).to be_truthy
-      expect(subject.set_shutdown(value: false)).to be_truthy
+      expect(subject.set_shutdown(enable: false)).to be_truthy
       expect(subject.get[:global][:shutdown]).to be_falsy
     end
 
     it 'configures mlag to be disabled' do
       node.config(['mlag configuration', 'no shutdown'])
       expect(subject.get[:global][:shutdown]).to be_falsy
-      expect(subject.set_shutdown(value: true)).to be_truthy
+      expect(subject.set_shutdown(enable: true)).to be_truthy
       expect(subject.get[:global][:shutdown]).to be_truthy
+    end
+
+    it 'defaults the shutdown value' do
+      expect(node).to receive(:config).with(['mlag configuration',
+                                             'default shutdown'])
+      expect(subject.set_shutdown(default: true)).to be_truthy
+    end
+  end
+
+  describe '#set_mlag_id' do
+    before do
+      node.config(['default mlag configuration',
+                   'default interface Ethernet1'])
+    end
+
+    # XXX Not clear how to test this feature
+    # it 'configures the mlag id' do
+    #   expect(subject.get[:global][:mlag_id]).to be_nil
+    #   expect(subject.set_mlag_id('Ethernet1', value: '1000')).to be_truthy
+    #   expect(subject.get[:global][:mlag_id]).to eq('1000')
+    # end
+    # XXX Replace the mock calls below
+    it 'negates the mlag id' do
+      expect(node).to receive(:config).with(['interface Ethernet1',
+                                             'no mlag'])
+      expect(subject.set_mlag_id('Ethernet1', enable: false)).to be_truthy
+    end
+
+    it 'defaults the mlag id' do
+      expect(node).to receive(:config).with(['interface Ethernet1',
+                                             'default mlag'])
+      expect(subject.set_mlag_id('Ethernet1', default: true)).to be_truthy
     end
   end
 end

--- a/spec/system/rbeapi/api/ntp_spec.rb
+++ b/spec/system/rbeapi/api/ntp_spec.rb
@@ -35,6 +35,20 @@ describe Rbeapi::Api::Ntp do
       expect(subject.set_source_interface(value: 'Loopback0')).to be_truthy
       expect(subject.get[:source_interface]).to eq('Loopback0')
     end
+
+    it 'negates the ntp source interface' do
+      expect(subject.set_source_interface(value: 'Loopback0')).to be_truthy
+      expect(subject.get[:source_interface]).to eq('Loopback0')
+      expect(subject.set_source_interface(enable: false)).to be_truthy
+      expect(subject.get[:source_interface]).to be_empty
+    end
+
+    it 'defaults the ntp source interface' do
+      expect(subject.set_source_interface(value: 'Loopback0')).to be_truthy
+      expect(subject.get[:source_interface]).to eq('Loopback0')
+      expect(subject.set_source_interface(default: true)).to be_truthy
+      expect(subject.get[:source_interface]).to be_empty
+    end
   end
 
   describe '#add_server' do

--- a/spec/system/rbeapi/api/snmp_spec.rb
+++ b/spec/system/rbeapi/api/snmp_spec.rb
@@ -118,4 +118,53 @@ describe Rbeapi::Api::Snmp do
       expect(subject.get[:source_interface]).to be_empty
     end
   end
+
+  describe '#set_community_acl' do
+    before do
+      node.config(['no snmp-server community foo',
+                   'no snmp-server community bar'])
+    end
+
+    it 'configures nil acl for snmp community foo and bar' do
+      expect(subject.get[:communities]).to be_empty
+      expect(subject.set_community_acl('foo')).to be_truthy
+      expect(subject.get[:communities]['foo']).to eq(access: 'ro', acl: nil)
+      expect(subject.set_community_acl('bar')).to be_truthy
+      expect(subject.get[:communities]['bar']).to eq(access: 'ro', acl: nil)
+    end
+
+    it 'configures IPv4 acl for snmp community foo and bar' do
+      expect(subject.get[:communities]).to be_empty
+      expect(subject.set_community_acl('foo', value: 'eng')).to be_truthy
+      expect(subject.get[:communities]['foo']).to eq(access: 'ro', acl: 'eng')
+      expect(subject.set_community_acl('bar', value: 'eng')).to be_truthy
+      expect(subject.get[:communities]['bar']).to eq(access: 'ro', acl: 'eng')
+    end
+
+    it 'negates the snmp community ACL for bar' do
+      expect(subject.get[:communities]).to be_empty
+      expect(subject.set_community_acl('foo', value: 'eng')).to be_truthy
+      expect(subject.get[:communities]['foo']).to eq(access: 'ro', acl: 'eng')
+      expect(subject.set_community_acl('bar', value: 'eng')).to be_truthy
+      expect(subject.get[:communities]['bar']).to eq(access: 'ro', acl: 'eng')
+      # Remove bar
+      expect(subject.set_community_acl('bar', enable: false)).to be_truthy
+      expect(subject.get[:communities]['bar']).to be_falsy
+      # Make sure foo is still there
+      expect(subject.get[:communities]['foo']).to eq(access: 'ro', acl: 'eng')
+    end
+
+    it 'defaults the snmp community ACL for bar' do
+      expect(subject.get[:communities]).to be_empty
+      expect(subject.set_community_acl('foo', value: 'eng')).to be_truthy
+      expect(subject.get[:communities]['foo']).to eq(access: 'ro', acl: 'eng')
+      expect(subject.set_community_acl('bar', value: 'eng')).to be_truthy
+      expect(subject.get[:communities]['bar']).to eq(access: 'ro', acl: 'eng')
+      # Default bar
+      expect(subject.set_community_acl('bar', default: true)).to be_truthy
+      expect(subject.get[:communities]['bar']).to be_falsy
+      # Make sure foo is still there
+      expect(subject.get[:communities]['foo']).to eq(access: 'ro', acl: 'eng')
+    end
+  end
 end

--- a/spec/system/rbeapi/api/snmp_spec.rb
+++ b/spec/system/rbeapi/api/snmp_spec.rb
@@ -31,6 +31,20 @@ describe Rbeapi::Api::Snmp do
       expect(subject.set_location(value: 'foo')).to be_truthy
       expect(subject.get[:location]).to eq('foo')
     end
+
+    it 'negates the snmp location' do
+      expect(subject.set_location(value: 'foo')).to be_truthy
+      expect(subject.get[:location]).to eq('foo')
+      expect(subject.set_location(enable: false)).to be_truthy
+      expect(subject.get[:location]).to be_empty
+    end
+
+    it 'defaults the snmp location' do
+      expect(subject.set_location(value: 'foo')).to be_truthy
+      expect(subject.get[:location]).to eq('foo')
+      expect(subject.set_location(default: true)).to be_truthy
+      expect(subject.get[:location]).to be_empty
+    end
   end
 
   describe '#set_contact' do
@@ -40,6 +54,20 @@ describe Rbeapi::Api::Snmp do
       expect(subject.get[:contact]).to be_empty
       expect(subject.set_contact(value: 'foo')).to be_truthy
       expect(subject.get[:contact]).to eq('foo')
+    end
+
+    it 'negates the snmp contact' do
+      expect(subject.set_contact(value: 'foo')).to be_truthy
+      expect(subject.get[:contact]).to eq('foo')
+      expect(subject.set_contact(enable: false)).to be_truthy
+      expect(subject.get[:contact]).to be_empty
+    end
+
+    it 'defaults the snmp contact' do
+      expect(subject.set_contact(value: 'foo')).to be_truthy
+      expect(subject.get[:contact]).to eq('foo')
+      expect(subject.set_contact(default: true)).to be_truthy
+      expect(subject.get[:contact]).to be_empty
     end
   end
 
@@ -51,6 +79,20 @@ describe Rbeapi::Api::Snmp do
       expect(subject.set_chassis_id(value: 'foo')).to be_truthy
       expect(subject.get[:chassis_id]).to eq('foo')
     end
+
+    it 'negates the chassis id' do
+      expect(subject.set_chassis_id(value: 'foo')).to be_truthy
+      expect(subject.get[:chassis_id]).to eq('foo')
+      expect(subject.set_chassis_id(enable: false)).to be_truthy
+      expect(subject.get[:chassis_id]).to be_empty
+    end
+
+    it 'defaults the chassis id' do
+      expect(subject.set_chassis_id(value: 'foo')).to be_truthy
+      expect(subject.get[:chassis_id]).to eq('foo')
+      expect(subject.set_chassis_id(default: true)).to be_truthy
+      expect(subject.get[:chassis_id]).to be_empty
+    end
   end
 
   describe '#set_source_interface' do
@@ -60,6 +102,20 @@ describe Rbeapi::Api::Snmp do
       expect(subject.get[:source_interface]).to be_empty
       expect(subject.set_source_interface(value: 'Loopback0')).to be_truthy
       expect(subject.get[:source_interface]).to eq('Loopback0')
+    end
+
+    it 'negates the snmp source-interface' do
+      expect(subject.set_source_interface(value: 'Loopback0')).to be_truthy
+      expect(subject.get[:source_interface]).to eq('Loopback0')
+      expect(subject.set_source_interface(enable: false)).to be_truthy
+      expect(subject.get[:source_interface]).to be_empty
+    end
+
+    it 'defaults the snmp source-interface' do
+      expect(subject.set_source_interface(value: 'Loopback0')).to be_truthy
+      expect(subject.get[:source_interface]).to eq('Loopback0')
+      expect(subject.set_source_interface(default: true)).to be_truthy
+      expect(subject.get[:source_interface]).to be_empty
     end
   end
 end

--- a/spec/system/rbeapi/api/stp_interfaces_spec.rb
+++ b/spec/system/rbeapi/api/stp_interfaces_spec.rb
@@ -58,18 +58,48 @@ describe Rbeapi::Api::StpInterfaces do
     end
   end
 
+  describe '#set_portfast_type' do
+    it 'raises an ArgumentError if value is not set' do
+      expect { subject.set_portfast_type('Ethernet1') }
+        .to raise_error(ArgumentError)
+    end
+
+    it 'enables portfast type' do
+      node.config(['interface Ethernet1', 'no spanning-tree portfast'])
+      expect(subject.get('Ethernet1')[:portfast_type]).to eq('normal')
+      expect(subject.set_portfast_type('Ethernet1', value: 'edge')).to be_truthy
+      expect(subject.get('Ethernet1')[:portfast_type]).to eq('edge')
+    end
+
+    it 'disable portfast' do
+      node.config(['interface Ethernet1', 'spanning-tree portfast edge'])
+      expect(subject.get('Ethernet1')[:portfast_type]).to eq('edge')
+      expect(subject.set_portfast_type('Ethernet1', value: 'edge',
+                                                    enable: false)).to be_truthy
+      expect(subject.get('Ethernet1')[:portfast_type]).to eq('normal')
+    end
+
+    it 'sets portfast to default value' do
+      node.config(['interface Ethernet1', 'spanning-tree portfast network'])
+      expect(subject.get('Ethernet1')[:portfast_type]).to eq('network')
+      expect(subject.set_portfast_type('Ethernet1', value: 'network',
+                                                    default: true)).to be_truthy
+      expect(subject.get('Ethernet1')[:portfast_type]).to eq('normal')
+    end
+  end
+
   describe '#set_bpduguard' do
     it 'sets the bpduguard value to true' do
       node.config(['interface Ethernet1', 'no spanning-tree bpduguard'])
       expect(subject.get('Ethernet1')[:bpduguard]).to be_falsy
-      expect(subject.set_bpduguard('Ethernet1', value: true)).to be_truthy
+      expect(subject.set_bpduguard('Ethernet1', enable: true)).to be_truthy
       expect(subject.get('Ethernet1')[:bpduguard]).to be_truthy
     end
 
     it 'sets the bpduguard value to false' do
       node.config(['interface Ethernet1', 'spanning-tree bpduguard enable'])
       expect(subject.get('Ethernet1')[:bpduguard]).to be_truthy
-      expect(subject.set_bpduguard('Ethernet1', value: false)).to be_truthy
+      expect(subject.set_bpduguard('Ethernet1', enable: false)).to be_truthy
       expect(subject.get('Ethernet1')[:bpduguard]).to be_falsy
     end
   end

--- a/spec/system/rbeapi/api/stp_interfaces_spec.rb
+++ b/spec/system/rbeapi/api/stp_interfaces_spec.rb
@@ -36,17 +36,24 @@ describe Rbeapi::Api::StpInterfaces do
   end
 
   describe '#set_portfast' do
-    it 'sets the portfast value to true' do
+    it 'enables portfast' do
       node.config(['interface Ethernet1', 'no spanning-tree portfast'])
       expect(subject.get('Ethernet1')[:portfast]).to be_falsy
-      expect(subject.set_portfast('Ethernet1', value: true)).to be_truthy
+      expect(subject.set_portfast('Ethernet1', enable: true)).to be_truthy
       expect(subject.get('Ethernet1')[:portfast]).to be_truthy
     end
 
-    it 'sets the portfast value to false' do
+    it 'disable portfast' do
       node.config(['interface Ethernet1', 'spanning-tree portfast'])
       expect(subject.get('Ethernet1')[:portfast]).to be_truthy
-      expect(subject.set_portfast('Ethernet1', value: false)).to be_truthy
+      expect(subject.set_portfast('Ethernet1', enable: false)).to be_truthy
+      expect(subject.get('Ethernet1')[:portfast]).to be_falsy
+    end
+
+    it 'sets portfast to default value' do
+      node.config(['interface Ethernet1', 'spanning-tree portfast'])
+      expect(subject.get('Ethernet1')[:portfast]).to be_truthy
+      expect(subject.set_portfast('Ethernet1', default: true)).to be_truthy
       expect(subject.get('Ethernet1')[:portfast]).to be_falsy
     end
   end

--- a/spec/system/rbeapi/api/stp_spec.rb
+++ b/spec/system/rbeapi/api/stp_spec.rb
@@ -46,12 +46,24 @@ describe Rbeapi::Api::Stp do
     end
 
     it 'sets the stp mode to none' do
-      node.config('spanning-tree mode mstp') do
-        node.config('spanning-tree mode mstp')
-        expect(subject.get[:mode]).to eq('mstp')
-        expect(subject.set_mode(value: 'none')).to be_truthy
-        expect(subject.get[:mode]).to eq('none')
-      end
+      node.config('spanning-tree mode mstp')
+      expect(subject.get[:mode]).to eq('mstp')
+      expect(subject.set_mode(value: 'none')).to be_truthy
+      expect(subject.get[:mode]).to eq('none')
+    end
+
+    it 'negates the stp mode' do
+      node.config('spanning-tree mode none')
+      expect(subject.get[:mode]).to eq('none')
+      expect(subject.set_mode(enable: false)).to be_truthy
+      expect(subject.get[:mode]).to eq('mstp')
+    end
+
+    it 'defaults the stp mode' do
+      node.config('spanning-tree mode none')
+      expect(subject.get[:mode]).to eq('none')
+      expect(subject.set_mode(default: true)).to be_truthy
+      expect(subject.get[:mode]).to eq('mstp')
     end
   end
 end

--- a/spec/system/rbeapi/api/switchports_spec.rb
+++ b/spec/system/rbeapi/api/switchports_spec.rb
@@ -95,6 +95,20 @@ describe Rbeapi::Api::Switchports do
       expect(subject.set_mode('Ethernet1', value: 'trunk')).to be_truthy
       expect(subject.get('Ethernet1')[:mode]).to eq('trunk')
     end
+
+    it 'negate the mode value' do
+      node.config(['interface Ethernet1', 'switchport mode trunk'])
+      expect(subject.get('Ethernet1')[:mode]).to eq('trunk')
+      expect(subject.set_mode('Ethernet1', enable: false)).to be_truthy
+      expect(subject.get('Ethernet1')[:mode]).to eq('access')
+    end
+
+    it 'default the mode value' do
+      node.config(['interface Ethernet1', 'switchport mode trunk'])
+      expect(subject.get('Ethernet1')[:mode]).to eq('trunk')
+      expect(subject.set_mode('Ethernet1', default: true)).to be_truthy
+      expect(subject.get('Ethernet1')[:mode]).to eq('access')
+    end
   end
 
   describe '#set_access_vlan' do
@@ -104,6 +118,22 @@ describe Rbeapi::Api::Switchports do
       expect(subject.get('Ethernet1')[:access_vlan]).to eq('1')
       expect(subject.set_access_vlan('Ethernet1', value: '100')).to be_truthy
       expect(subject.get('Ethernet1')[:access_vlan]).to eq('100')
+    end
+
+    it 'negates the access vlan value' do
+      expect(subject.get('Ethernet1')[:access_vlan]).to eq('1')
+      expect(subject.set_access_vlan('Ethernet1', value: '100')).to be_truthy
+      expect(subject.get('Ethernet1')[:access_vlan]).to eq('100')
+      expect(subject.set_access_vlan('Ethernet1', enable: false)).to be_truthy
+      expect(subject.get('Ethernet1')[:access_vlan]).to eq('1')
+    end
+
+    it 'defaults the access vlan value' do
+      expect(subject.get('Ethernet1')[:access_vlan]).to eq('1')
+      expect(subject.set_access_vlan('Ethernet1', value: '100')).to be_truthy
+      expect(subject.get('Ethernet1')[:access_vlan]).to eq('100')
+      expect(subject.set_access_vlan('Ethernet1', default: true)).to be_truthy
+      expect(subject.get('Ethernet1')[:access_vlan]).to eq('1')
     end
   end
 
@@ -116,6 +146,26 @@ describe Rbeapi::Api::Switchports do
         .to be_truthy
       expect(subject.get('Ethernet1')[:trunk_native_vlan]).to eq('100')
     end
+
+    it 'negates the trunk native vlan' do
+      expect(subject.get('Ethernet1')[:trunk_native_vlan]).to eq('1')
+      expect(subject.set_trunk_native_vlan('Ethernet1', value: '100'))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:trunk_native_vlan]).to eq('100')
+      expect(subject.set_trunk_native_vlan('Ethernet1', enable: false))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:trunk_native_vlan]).to eq('1')
+    end
+
+    it 'defaults the trunk native vlan' do
+      expect(subject.get('Ethernet1')[:trunk_native_vlan]).to eq('1')
+      expect(subject.set_trunk_native_vlan('Ethernet1', value: '100'))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:trunk_native_vlan]).to eq('100')
+      expect(subject.set_trunk_native_vlan('Ethernet1', default: true))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:trunk_native_vlan]).to eq('1')
+    end
   end
 
   describe '#set_trunk_allowed_vlans' do
@@ -126,12 +176,34 @@ describe Rbeapi::Api::Switchports do
         .to raise_error(ArgumentError)
     end
 
-    it 'sets vlan 100 to the trunk allowed vlans' do
+    it 'sets vlan 8 and 9 to the trunk allowed vlans' do
       node.config(['interface Ethernet1', 'switchport trunk allowed vlan none'])
       expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to be_empty
-      expect(subject.set_trunk_allowed_vlans('Ethernet1', value: [100]))
+      expect(subject.set_trunk_allowed_vlans('Ethernet1', value: [8, 9]))
         .to be_truthy
-      expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to include(100)
+      expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to eq([8, 9])
+    end
+
+    it 'negate switchport trunk allowed vlan' do
+      node.config(['interface Ethernet1', 'switchport trunk allowed vlan none'])
+      expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to be_empty
+      expect(subject.set_trunk_allowed_vlans('Ethernet1', value: [8, 9]))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to eq([8, 9])
+      expect(subject.set_trunk_allowed_vlans('Ethernet1', enable: false))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:trunk_allowed_vlans].length).to eq(4094)
+    end
+
+    it 'default switchport trunk allowed vlan' do
+      node.config(['interface Ethernet1', 'switchport trunk allowed vlan none'])
+      expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to be_empty
+      expect(subject.set_trunk_allowed_vlans('Ethernet1', value: [8, 9]))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to eq([8, 9])
+      expect(subject.set_trunk_allowed_vlans('Ethernet1', default: true))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:trunk_allowed_vlans].length).to eq(4094)
     end
   end
 end

--- a/spec/system/rbeapi/api/system_spec.rb
+++ b/spec/system/rbeapi/api/system_spec.rb
@@ -31,5 +31,15 @@ describe Rbeapi::Api::System do
       expect(subject.set_hostname(value: 'foo')).to be_truthy
       expect(subject.get[:hostname]).to eq('foo')
     end
+
+    it 'negates the hostname' do
+      expect(subject.set_hostname(enable: false)).to be_truthy
+      expect(subject.get[:hostname]).to be_empty
+    end
+
+    it 'defaults the hostname' do
+      expect(subject.set_hostname(default: true)).to be_truthy
+      expect(subject.get[:hostname]).to be_empty
+    end
   end
 end

--- a/spec/system/rbeapi/api/system_spec.rb
+++ b/spec/system/rbeapi/api/system_spec.rb
@@ -32,6 +32,12 @@ describe Rbeapi::Api::System do
       expect(subject.get[:hostname]).to eq('foo')
     end
 
+    it 'configures the system hostname with a dot value' do
+      expect(subject.get[:hostname]).to eq('localhost')
+      expect(subject.set_hostname(value: 'foo.bar')).to be_truthy
+      expect(subject.get[:hostname]).to eq('foo.bar')
+    end
+
     it 'negates the hostname' do
       expect(subject.set_hostname(enable: false)).to be_truthy
       expect(subject.get[:hostname]).to be_empty

--- a/spec/system/rbeapi/api/vlans_spec.rb
+++ b/spec/system/rbeapi/api/vlans_spec.rb
@@ -91,6 +91,20 @@ describe Rbeapi::Api::Vlans do
       expect(subject.set_name('1', value: 'foo')).to be_truthy
       expect(subject.get('1')[:name]).to eq('foo')
     end
+
+    it 'negates the vlan name' do
+      expect(subject.set_name('1', value: 'foo')).to be_truthy
+      expect(subject.get('1')[:name]).to eq('foo')
+      expect(subject.set_name('1', enable: false)).to be_truthy
+      expect(subject.get('1')[:name]).to eq('default')
+    end
+
+    it 'defaults the vlan name' do
+      expect(subject.set_name('1', value: 'foo')).to be_truthy
+      expect(subject.get('1')[:name]).to eq('foo')
+      expect(subject.set_name('1', default: true)).to be_truthy
+      expect(subject.get('1')[:name]).to eq('default')
+    end
   end
 
   describe '#set_state' do
@@ -105,6 +119,20 @@ describe Rbeapi::Api::Vlans do
       node.config(['vlan 1', 'state suspend'])
       expect(subject.get('1')[:state]).to eq('suspend')
       expect(subject.set_state('1', value: 'active')).to be_truthy
+      expect(subject.get('1')[:state]).to eq('active')
+    end
+
+    it 'negate vlan 1 state' do
+      node.config(['vlan 1', 'state suspend'])
+      expect(subject.get('1')[:state]).to eq('suspend')
+      expect(subject.set_state('1', enable: false)).to be_truthy
+      expect(subject.get('1')[:state]).to eq('active')
+    end
+
+    it 'set vlan 1 state to default' do
+      node.config(['vlan 1', 'state suspend'])
+      expect(subject.get('1')[:state]).to eq('suspend')
+      expect(subject.set_state('1', default: true)).to be_truthy
       expect(subject.get('1')[:state]).to eq('active')
     end
   end

--- a/spec/unit/rbeapi/api/interfaces/base_spec.rb
+++ b/spec/unit/rbeapi/api/interfaces/base_spec.rb
@@ -71,7 +71,7 @@ describe Rbeapi::Api::BaseInterface do
     it 'negates the interface description' do
       expect(node).to receive(:config).with(['interface Loopback0',
                                              'no description'])
-      expect(subject.set_description('Loopback0')).to be_truthy
+      expect(subject.set_description('Loopback0', enable: false)).to be_truthy
     end
 
     it 'defaults the interface description' do
@@ -80,10 +80,10 @@ describe Rbeapi::Api::BaseInterface do
       expect(subject.set_description('Loopback0', default: true)).to be_truthy
     end
 
-    it 'default is preferred over value' do
+    it 'default is preferred over enable' do
       expect(node).to receive(:config).with(['interface Loopback0',
                                              'default description'])
-      expect(subject.set_description('Loopback0', value: 'test',
+      expect(subject.set_description('Loopback0', enable: false,
                                                   default: true)).to be_truthy
     end
   end
@@ -92,19 +92,13 @@ describe Rbeapi::Api::BaseInterface do
     it 'enables the interface' do
       expect(node).to receive(:config).with(['interface Loopback0',
                                              'no shutdown'])
-      expect(subject.set_shutdown('Loopback0', value: false)).to be_truthy
+      expect(subject.set_shutdown('Loopback0', enable: false)).to be_truthy
     end
 
     it 'disables the interface' do
       expect(node).to receive(:config).with(['interface Loopback0',
                                              'shutdown'])
-      expect(subject.set_shutdown('Loopback0', value: true)).to be_truthy
-    end
-
-    it 'negates the interface description' do
-      expect(node).to receive(:config).with(['interface Loopback0',
-                                             'no shutdown'])
-      expect(subject.set_shutdown('Loopback0')).to be_truthy
+      expect(subject.set_shutdown('Loopback0', enable: true)).to be_truthy
     end
 
     it 'defaults the interface state' do
@@ -113,10 +107,10 @@ describe Rbeapi::Api::BaseInterface do
       expect(subject.set_shutdown('Loopback0', default: true)).to be_truthy
     end
 
-    it 'default is preferred over value' do
+    it 'default is preferred over enable' do
       expect(node).to receive(:config).with(['interface Loopback0',
                                              'default shutdown'])
-      expect(subject.set_shutdown('Loopback0', value: 'test',
+      expect(subject.set_shutdown('Loopback0', enable: false,
                                                default: true)).to be_truthy
     end
   end

--- a/spec/unit/rbeapi/api/interfaces/ethernet_spec.rb
+++ b/spec/unit/rbeapi/api/interfaces/ethernet_spec.rb
@@ -70,7 +70,7 @@ describe Rbeapi::Api::EthernetInterface do
     it 'negates the interface description' do
       expect(node).to receive(:config).with(['interface Ethernet1',
                                              'no description'])
-      expect(subject.set_description('Ethernet1')).to be_truthy
+      expect(subject.set_description('Ethernet1', enable: false)).to be_truthy
     end
 
     it 'defaults the interface description' do
@@ -79,10 +79,10 @@ describe Rbeapi::Api::EthernetInterface do
       expect(subject.set_description('Ethernet1', default: true)).to be_truthy
     end
 
-    it 'default is preferred over value' do
+    it 'default is preferred over enable' do
       expect(node).to receive(:config).with(['interface Ethernet1',
                                              'default description'])
-      expect(subject.set_description('Ethernet1', value: 'test',
+      expect(subject.set_description('Ethernet1', enable: false,
                                                   default: true)).to be_truthy
     end
   end

--- a/spec/unit/rbeapi/api/interfaces/portchannel_spec.rb
+++ b/spec/unit/rbeapi/api/interfaces/portchannel_spec.rb
@@ -89,7 +89,8 @@ describe Rbeapi::Api::PortchannelInterface do
       expect(node).to receive(:config)
         .with(['interface Port-Channel1', 'no description'])
 
-      expect(subject.set_description('Port-Channel1')).to be_truthy
+      expect(subject.set_description('Port-Channel1',
+                                     enable: false)).to be_truthy
     end
 
     it 'defaults the interface description' do
@@ -100,11 +101,11 @@ describe Rbeapi::Api::PortchannelInterface do
         .to be_truthy
     end
 
-    it 'default is preferred over value' do
+    it 'default is preferred over enable' do
       expect(node).to receive(:config)
         .with(['interface Port-Channel1', 'default description'])
 
-      opts = { value: 'test', default: true }
+      opts = { enable: false, default: true }
       expect(subject.set_description('Port-Channel1', opts)).to be_truthy
     end
   end
@@ -114,21 +115,21 @@ describe Rbeapi::Api::PortchannelInterface do
       expect(node).to receive(:config)
         .with(['interface Port-Channel1', 'no shutdown'])
 
-      expect(subject.set_shutdown('Port-Channel1', value: false)).to be_truthy
+      expect(subject.set_shutdown('Port-Channel1', enable: false)).to be_truthy
     end
 
     it 'disables the interface' do
       expect(node).to receive(:config)
         .with(['interface Port-Channel1', 'shutdown'])
 
-      expect(subject.set_shutdown('Port-Channel1', value: true)).to be_truthy
+      expect(subject.set_shutdown('Port-Channel1', enable: true)).to be_truthy
     end
 
     it 'negates the interface description' do
       expect(node).to receive(:config)
         .with(['interface Port-Channel1', 'no shutdown'])
 
-      expect(subject.set_shutdown('Port-Channel1')).to be_truthy
+      expect(subject.set_shutdown('Port-Channel1', enable: false)).to be_truthy
     end
 
     it 'defaults the interface state' do
@@ -138,11 +139,11 @@ describe Rbeapi::Api::PortchannelInterface do
       expect(subject.set_shutdown('Port-Channel1', default: true)).to be_truthy
     end
 
-    it 'default is preferred over value' do
+    it 'default is preferred over enable' do
       expect(node).to receive(:config)
         .with(['interface Port-Channel1', 'default shutdown'])
 
-      opts = { value: 'test', default: true }
+      opts = { enable: false, default: true }
       expect(subject.set_shutdown('Port-Channel1', opts)).to be_truthy
     end
   end

--- a/spec/unit/rbeapi/api/interfaces/vxlan_spec.rb
+++ b/spec/unit/rbeapi/api/interfaces/vxlan_spec.rb
@@ -72,7 +72,7 @@ describe Rbeapi::Api::VxlanInterface do
     it 'negates the vxlan source interface value' do
       commands = ['interface Vxlan1', 'no vxlan source-interface']
       expect(node).to receive(:config).with(commands)
-      expect(subject.set_source_interface('Vxlan1')).to be_truthy
+      expect(subject.set_source_interface('Vxlan1', enable: false)).to be_truthy
     end
 
     it 'defaults the source interface setting' do
@@ -82,9 +82,9 @@ describe Rbeapi::Api::VxlanInterface do
       expect(subject.set_source_interface('Vxlan1', opts)).to be_truthy
     end
 
-    it 'prefers default over value' do
+    it 'prefers default over enable' do
       commands = ['interface Vxlan1', 'default vxlan source-interface']
-      opts = { default: true, value: 'Looback0' }
+      opts = { default: true, enable: false }
       expect(node).to receive(:config).with(commands)
       expect(subject.set_source_interface('Vxlan1', opts)).to be_truthy
     end
@@ -101,7 +101,7 @@ describe Rbeapi::Api::VxlanInterface do
     it 'negates the vxlan multicast group value' do
       commands = ['interface Vxlan1', 'no vxlan multicast-group']
       expect(node).to receive(:config).with(commands)
-      expect(subject.set_multicast_group('Vxlan1')).to be_truthy
+      expect(subject.set_multicast_group('Vxlan1', enable: false)).to be_truthy
     end
 
     it 'defaults the multicast group setting' do
@@ -113,7 +113,7 @@ describe Rbeapi::Api::VxlanInterface do
 
     it 'prefers default over value' do
       commands = ['interface Vxlan1', 'default vxlan multicast-group']
-      opts = { default: true, value: '239.10.10.10' }
+      opts = { default: true, enable: false }
       expect(node).to receive(:config).with(commands)
       expect(subject.set_multicast_group('Vxlan1', opts)).to be_truthy
     end
@@ -130,7 +130,7 @@ describe Rbeapi::Api::VxlanInterface do
     it 'negates the vxlan udp-port value' do
       commands = ['interface Vxlan1', 'no vxlan udp-port']
       expect(node).to receive(:config).with(commands)
-      expect(subject.set_udp_port('Vxlan1')).to be_truthy
+      expect(subject.set_udp_port('Vxlan1', enable: false)).to be_truthy
     end
 
     it 'defaults the vxlan udp-port setting' do
@@ -140,9 +140,9 @@ describe Rbeapi::Api::VxlanInterface do
       expect(subject.set_udp_port('Vxlan1', opts)).to be_truthy
     end
 
-    it 'prefers default over value' do
+    it 'prefers default over enable' do
       commands = ['interface Vxlan1', 'default vxlan udp-port']
-      opts = { default: true, value: '1024' }
+      opts = { default: true, enable: false }
       expect(node).to receive(:config).with(commands)
       expect(subject.set_udp_port('Vxlan1', opts)).to be_truthy
     end
@@ -191,7 +191,7 @@ describe Rbeapi::Api::VxlanInterface do
     it 'negates the interface description' do
       expect(node).to receive(:config).with(['interface Vxlan1',
                                              'no description'])
-      expect(subject.set_description('Vxlan1')).to be_truthy
+      expect(subject.set_description('Vxlan1', enable: false)).to be_truthy
     end
 
     it 'defaults the interface description' do
@@ -200,10 +200,10 @@ describe Rbeapi::Api::VxlanInterface do
       expect(subject.set_description('Vxlan1', default: true)).to be_truthy
     end
 
-    it 'default is preferred over value' do
+    it 'default is preferred over enable' do
       expect(node).to receive(:config).with(['interface Vxlan1',
                                              'default description'])
-      expect(subject.set_description('Vxlan1', value: 'test',
+      expect(subject.set_description('Vxlan1', enable: false,
                                                default: true)).to be_truthy
     end
   end
@@ -212,19 +212,19 @@ describe Rbeapi::Api::VxlanInterface do
     it 'enables the interface' do
       expect(node).to receive(:config).with(['interface Vxlan1',
                                              'no shutdown'])
-      expect(subject.set_shutdown('Vxlan1', value: false)).to be_truthy
+      expect(subject.set_shutdown('Vxlan1', enable: false)).to be_truthy
     end
 
     it 'disables the interface' do
       expect(node).to receive(:config).with(['interface Vxlan1',
                                              'shutdown'])
-      expect(subject.set_shutdown('Vxlan1', value: true)).to be_truthy
+      expect(subject.set_shutdown('Vxlan1', enable: true)).to be_truthy
     end
 
     it 'negates the interface description' do
       expect(node).to receive(:config).with(['interface Vxlan1',
                                              'no shutdown'])
-      expect(subject.set_shutdown('Vxlan1')).to be_truthy
+      expect(subject.set_shutdown('Vxlan1', enable: false)).to be_truthy
     end
 
     it 'defaults the interface state' do
@@ -233,10 +233,10 @@ describe Rbeapi::Api::VxlanInterface do
       expect(subject.set_shutdown('Vxlan1', default: true)).to be_truthy
     end
 
-    it 'default is preferred over value' do
+    it 'default is preferred over enable' do
       expect(node).to receive(:config).with(['interface Vxlan1',
                                              'default shutdown'])
-      expect(subject.set_shutdown('Vxlan1', value: 'test', default: true))
+      expect(subject.set_shutdown('Vxlan1', enable: false, default: true))
         .to be_truthy
     end
   end

--- a/spec/unit/rbeapi/api/mlag/default_spec.rb
+++ b/spec/unit/rbeapi/api/mlag/default_spec.rb
@@ -60,7 +60,7 @@ describe Rbeapi::Api::Mlag do
     it 'negates the domain_id' do
       expect(node).to receive(:config).with(['mlag configuration',
                                              'no domain-id'])
-      expect(subject.set_domain_id).to be_truthy
+      expect(subject.set_domain_id(enable: false)).to be_truthy
     end
 
     it 'defaults the domain_id' do
@@ -72,7 +72,7 @@ describe Rbeapi::Api::Mlag do
     it 'default option takes precedence' do
       expect(node).to receive(:config).with(['mlag configuration',
                                              'default domain-id'])
-      expect(subject.set_domain_id(value: 'foo', default: true)).to be_truthy
+      expect(subject.set_domain_id(enable: false, default: true)).to be_truthy
     end
   end
 
@@ -86,7 +86,7 @@ describe Rbeapi::Api::Mlag do
     it 'negates the local_interface' do
       expect(node).to receive(:config).with(['mlag configuration',
                                              'no local-interface'])
-      expect(subject.set_local_interface).to be_truthy
+      expect(subject.set_local_interface(enable: false)).to be_truthy
     end
 
     it 'defaults the local_interface' do
@@ -98,7 +98,7 @@ describe Rbeapi::Api::Mlag do
     it 'default option takes precedence' do
       expect(node).to receive(:config).with(['mlag configuration',
                                              'default local-interface'])
-      expect(subject.set_local_interface(value: 'Port-Channel1',
+      expect(subject.set_local_interface(enable: false,
                                          default: true)).to be_truthy
     end
   end
@@ -113,7 +113,7 @@ describe Rbeapi::Api::Mlag do
     it 'negates the peer_address' do
       expect(node).to receive(:config).with(['mlag configuration',
                                              'no peer-address'])
-      expect(subject.set_peer_address).to be_truthy
+      expect(subject.set_peer_address(enable: false)).to be_truthy
     end
 
     it 'defaults the peer_address' do
@@ -125,7 +125,7 @@ describe Rbeapi::Api::Mlag do
     it 'default option takes precedence' do
       expect(node).to receive(:config).with(['mlag configuration',
                                              'default peer-address'])
-      expect(subject.set_peer_address(value: '1.1.1.1',
+      expect(subject.set_peer_address(enable: false,
                                       default: true)).to be_truthy
     end
   end
@@ -140,7 +140,7 @@ describe Rbeapi::Api::Mlag do
     it 'negates the peer_link' do
       expect(node).to receive(:config).with(['mlag configuration',
                                              'no peer-link'])
-      expect(subject.set_peer_link).to be_truthy
+      expect(subject.set_peer_link(enable: false)).to be_truthy
     end
 
     it 'defaults the peer_link' do
@@ -152,7 +152,7 @@ describe Rbeapi::Api::Mlag do
     it 'default option takes precedence' do
       expect(node).to receive(:config).with(['mlag configuration',
                                              'default peer-link'])
-      expect(subject.set_peer_link(value: 'Vlan4094', default: true))
+      expect(subject.set_peer_link(enable: false, default: true))
         .to be_truthy
     end
   end
@@ -167,7 +167,7 @@ describe Rbeapi::Api::Mlag do
     it 'negates the mlag_id' do
       expect(node).to receive(:config).with(['interface Port-Channel1',
                                              'no mlag'])
-      expect(subject.set_mlag_id('Port-Channel1')).to be_truthy
+      expect(subject.set_mlag_id('Port-Channel1', enable: false)).to be_truthy
     end
 
     it 'defaults the mlag_id' do
@@ -179,7 +179,7 @@ describe Rbeapi::Api::Mlag do
     it 'default option takes precedence' do
       expect(node).to receive(:config).with(['interface Port-Channel1',
                                              'default mlag'])
-      expect(subject.set_mlag_id('Port-Channel1', value: 'Vlan4094',
+      expect(subject.set_mlag_id('Port-Channel1', enable: false,
                                                   default: true)).to be_truthy
     end
   end
@@ -188,19 +188,19 @@ describe Rbeapi::Api::Mlag do
     it 'disables the mlag configuration' do
       expect(node).to receive(:config).with(['mlag configuration',
                                              'shutdown'])
-      expect(subject.set_shutdown(value: true)).to be_truthy
+      expect(subject.set_shutdown(enable: true)).to be_truthy
     end
 
     it 'enables the mlag configuration' do
       expect(node).to receive(:config).with(['mlag configuration',
                                              'no shutdown'])
-      expect(subject.set_shutdown(value: false)).to be_truthy
+      expect(subject.set_shutdown(enable: false)).to be_truthy
     end
 
     it 'negates the shutdown value' do
       expect(node).to receive(:config).with(['mlag configuration',
                                              'no shutdown'])
-      expect(subject.set_shutdown).to be_truthy
+      expect(subject.set_shutdown(enable: false)).to be_truthy
     end
 
     it 'defaults the shutdown value' do
@@ -212,7 +212,7 @@ describe Rbeapi::Api::Mlag do
     it 'default option takes precedence' do
       expect(node).to receive(:config).with(['mlag configuration',
                                              'default shutdown'])
-      expect(subject.set_shutdown(value: true, default: true)).to be_truthy
+      expect(subject.set_shutdown(enable: false, default: true)).to be_truthy
     end
   end
 end

--- a/spec/unit/rbeapi/api/vlans/default_spec.rb
+++ b/spec/unit/rbeapi/api/vlans/default_spec.rb
@@ -72,7 +72,7 @@ describe Rbeapi::Api::Vlans do
 
     it 'negates vlan name' do
       expect(node).to receive(:config).with(['vlan 1', 'no name'])
-      expect(subject.set_name('1')).to be_truthy
+      expect(subject.set_name('1', enable: false)).to be_truthy
     end
 
     it 'defaults the vlan name' do
@@ -82,7 +82,7 @@ describe Rbeapi::Api::Vlans do
 
     it 'default option takes precedence' do
       expect(node).to receive(:config).with(['vlan 1', 'default name'])
-      expect(subject.set_name('1', value: 'foo', default: true)).to be_truthy
+      expect(subject.set_name('1', enable: false, default: true)).to be_truthy
     end
   end
 
@@ -99,7 +99,7 @@ describe Rbeapi::Api::Vlans do
 
     it 'negates the state' do
       expect(node).to receive(:config).with(['vlan 1', 'no state'])
-      expect(subject.set_state('1')).to be_truthy
+      expect(subject.set_state('1', enable: false)).to be_truthy
     end
 
     it 'defaults the state' do
@@ -109,7 +109,7 @@ describe Rbeapi::Api::Vlans do
 
     it 'default option take precedence' do
       expect(node).to receive(:config).with(['vlan 1', 'default state'])
-      expect(subject.set_state('1', value: 'active', default: true)).to \
+      expect(subject.set_state('1', enable: false, default: true)).to \
         be_truthy
     end
 


### PR DESCRIPTION
Command builder currently overloads the value parameter. When the value
is set it is used as a value in building the command. When the value is
false then the command is negated. This doesn't allow a value to be
specified when the command is negated.

Not all the api modules are using command builder so they were updated to do so.

The advantage of having all the simple command methods that use
default/no is that the same library is used consistently throughout the
modules reducing duplicated code patterns.

Test cases for no/default cases of set methods were added.