### PR TITLE
add dry-run mode

### DIFF
--- a/lib/rbeapi/client.rb
+++ b/lib/rbeapi/client.rb
@@ -266,6 +266,7 @@ module Rbeapi
     # for handling both enable mode and config mode commands
     class Node
       attr_reader :connection
+      attr_accessor :dry_run
 
       ##
       # Save the connection and set autorefresh to true.
@@ -275,6 +276,7 @@ module Rbeapi
       def initialize(connection)
         @connection = connection
         @autorefresh = true
+        @dry_run = false
       end
 
       ##
@@ -329,12 +331,18 @@ module Rbeapi
         commands = [*commands] unless commands.respond_to?('each')
 
         commands.insert(0, 'configure')
-        response = run_commands(commands, opts)
 
-        refresh if @autorefresh
+        if @dry_run then
+          puts "[rbeapi dry-run commands]"
+          puts commands
+        else
+          response = run_commands(commands, opts)
 
-        response.shift
-        response
+          refresh if @autorefresh
+
+          response.shift
+          response
+        end
       end
 
       ##


### PR DESCRIPTION
Added `dry_run` boolean attribute to `Rbeapi::Client::Node` .

If `Node.dry_run` is `true` , `Node.config` DO NOT executes eAPI request to device and only print stdout `[rbeapi dry-run commands]` and `commands` .
(`Node.enable` , `Node.get_config` and so on are not affected.)

Will work as below.
```ruby
require 'rbeapi/client'

node = Rbeapi::Client.connect_to('vEOS-spine001')
node.dry_run = true

hash_vlans = node.enable('show vlan')[0][:result]["vlans"] rescue nil
p hash_vlans

hash_vlans.each_key do |vlan|
  next if (vlan.to_i == 1 || vlan.to_i == 4094)
  node.config([
    "interface Po1",
    " switchport trunk allowed vlan add #{vlan}"
  ])
end
```
Results in as below.
```bash
[kotetsu@centos66-ruby 201507_rbeapi_test_dryrun]$ ruby rbeapi_test_dryrun.rb
{"1"=>{"status"=>"active", "name"=>"default", "interfaces"=>{}, "dynamic"=>false}, "4094"=>{"status"=>"active", "name"=>"VLAN4094", "interfaces"=>{"Cpu"=>{"privatePromoted"=>false}}, "dynamic"=>false}, "31"=>{"status"=>"active", "name"=>"VLAN0031", "interfaces"=>{}, "dynamic"=>false}, "30"=>{"status"=>"active", "name"=>"VLAN0030", "interfaces"=>{}, "dynamic"=>false}}

[rbeapi dry-run commands]
configure
interface Po1
 switchport trunk allowed vlan add 31
[rbeapi dry-run commands]
configure
interface Po1
 switchport trunk allowed vlan add 30
```
