### PR TITLE
Ensure that nil is returned when you try to get nonexistent username.

### DIFF
--- a/lib/rbeapi/api/users.rb
+++ b/lib/rbeapi/api/users.rb
@@ -94,7 +94,7 @@ module Rbeapi
                               (username\s+#{name}\s+
                                sshkey\s+(?<sshkey>.*)$)?/x)
         user = config.scan(user_re)
-        return nil unless user
+        return nil unless user && user[0]
         parse_user_entry(user[0])
       end
 


### PR DESCRIPTION
Ensure nil is returned when you try to get nonexistent username. Ran into this issue while creating user system tests.