### PR TITLE
Ensure all parse methods are private.

### DIFF
--- a/lib/rbeapi/api/dns.rb
+++ b/lib/rbeapi/api/dns.rb
@@ -64,17 +64,20 @@ module Rbeapi
         mdata = /ip domain-name ([\w.]+)/.match(config)
         { domain_name: mdata.nil? ? '' : mdata[1] }
       end
+      private :parse_domain_name
 
       def parse_name_servers
         servers = config.scan(/(?:ip name-server vrf )(?:\w+)\s(.+)/)
         values = servers.each_with_object([]) { |srv, arry| arry << srv.first }
         { name_servers: values }
       end
+      private :parse_name_servers
 
       def parse_domain_list
         search = config.scan(/(?<=^ip\sdomain-list\s).+$/)
         { domain_list: search }
       end
+      private :parse_domain_list
 
       ##
       # Configure the domain-name value in the running-config

--- a/lib/rbeapi/api/logging.rb
+++ b/lib/rbeapi/api/logging.rb
@@ -80,6 +80,7 @@ module Rbeapi
         hosts = config.scan(/(?<=^logging\shost\s)[^\s]+/)
         { hosts: hosts }
       end
+      private :parse_hosts
 
       ##
       # set_enable configures the global logging instance on the node as either

--- a/lib/rbeapi/api/ntp.rb
+++ b/lib/rbeapi/api/ntp.rb
@@ -95,6 +95,7 @@ module Rbeapi
         end
         { servers: values }
       end
+      private :parse_servers
 
       ##
       # set_source_interface configures the ntp source value in the nodes

--- a/lib/rbeapi/api/system.rb
+++ b/lib/rbeapi/api/system.rb
@@ -62,11 +62,13 @@ module Rbeapi
         mdata = /(?<=^hostname\s)(.+)$/.match(config)
         { hostname: mdata.nil? ? '' : mdata[1] }
       end
+      private :parse_hostname
 
       def parse_iprouting(config)
         mdata = /no\sip\srouting/.match(config)
         { iprouting: mdata.nil? ? true : false }
       end
+      private :parse_iprouting
 
       ##
       # Configures the system hostname value in the running-config


### PR DESCRIPTION
Noticed a few parse methods that weren't private while updating documentation.