### PR TITLE
Catch errors and syslog them when parsing eapi conf file.

### DIFF
--- a/lib/rbeapi/client.rb
+++ b/lib/rbeapi/client.rb
@@ -90,7 +90,7 @@ module Rbeapi
       end
 
       ##
-      # Retrieves the node config form the loaded configuration file and
+      # Retrieves the node config from the loaded configuration file and
       # returns a Rbeapi::Node instance for working with the remote node.
       #
       # @param [String] :name The named configuration to use for creating the
@@ -110,10 +110,7 @@ module Rbeapi
       ##
       # Builds a connection object to a remote node using the specified
       # options and return an instance of Rbeapi::Connection.  All
-      # configuration options can be passed via the :opts param or can be
-      # overridden using environment variables.  Environment variables are
-      # specified by prepending EAPI to the option name.  For instance to
-      # override the host param use EAPI_HOST.
+      # configuration options can be passed via the :opts param.
       #
       # @param [Hash] :opts the options to create a message with
       # @option :opts [String] :host The IP address or hostname of the remote
@@ -205,7 +202,12 @@ module Rbeapi
       #
       # @param [String] :filename The full path to the filename to load
       def read(filename)
-        super(filename: filename)
+        begin
+          super(filename: filename)
+        rescue IniFile::Error => exc
+          Rbeapi::Utils.syslog_warning("#{exc}: in eapi conf file: #{filename}")
+          return
+        end
 
         # For each section, if the host parameter is omitted then the
         # connection name is used
@@ -252,13 +254,14 @@ module Rbeapi
       end
 
       ##
-      # Adds a new connection section  to the current configuration
+      # Adds a new connection section to the current configuration
       #
       # @param [String] :name The name of the connection to add to the
       #   configuration.
       # @param [Hash] :values The properties for the connection
       def add_connection(name, values)
         self["connection:#{name}"] = values
+        nil
       end
     end
 

--- a/lib/rbeapi/utils.rb
+++ b/lib/rbeapi/utils.rb
@@ -30,6 +30,8 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+require 'syslog'
+
 ##
 # Rbeapi toplevel namespace
 module Rbeapi
@@ -63,6 +65,14 @@ module Rbeapi
       name.split('::').inject(Object) do |mod, cls|
         mod.const_get(cls)
       end
+    end
+
+    ##
+    # Syslogs a warning message.
+    #
+    # @param [String] :message The message to log.
+    def self.syslog_warning(message)
+      Syslog.open('rbeapi', Syslog::LOG_PID) { |s| s.warning message }
     end
   end
 end

--- a/spec/fixtures/eapi.conf.yaml
+++ b/spec/fixtures/eapi.conf.yaml
@@ -1,0 +1,6 @@
+---
+:username: admin
+:password: admin
+:use_ssl: true
+:port: 199
+:hostname: bogus

--- a/spec/fixtures/env_path.conf
+++ b/spec/fixtures/env_path.conf
@@ -1,0 +1,5 @@
+[connection:env_path]
+host: 172.16.131.40
+username: admin
+password: admin
+transport: https

--- a/spec/system/rbeapi/client_spec.rb
+++ b/spec/system/rbeapi/client_spec.rb
@@ -81,16 +81,7 @@ describe Rbeapi::Client do
 
   let(:test_data) do
     [
-      '[connection:veos01]',
-      '[connection:veos02]',
-      '[connection:veos03',
-      '[connection:veos04]',
-      '[connection:veos05]',
-      '[connection: localhost]',
-      'username',
-      'password',
-      'transport',
-      'host'
+      '[connection:veos01]'
     ]
   end
 
@@ -142,7 +133,7 @@ describe Rbeapi::Client do
 
   describe '#read' do
     it 'read the specified filename and load dut' do
-      expect(subject.config.read(dut_conf)).to eq(transport: 'socket')
+      expect(subject.config.read(dut_conf)).to eq(nil)
       expect(subject.config.to_s)
         .to include('host', 'username', 'password', '[connection:dut]')
     end
@@ -166,8 +157,7 @@ describe Rbeapi::Client do
   describe '#reload' do
     it 'reloads the configuration file' do
       expect(subject.config.get_connection('veos01')).to eq(veos01)
-      expect(subject.config.reload(filename: [dut_conf]))
-        .to eq(transport: 'socket')
+      expect(subject.config.reload(filename: [dut_conf])).to eq(nil)
       expect(subject.config.get_connection('veos01')).to eq(nil)
       expect(subject.config.get_connection('dut')).not_to be_nil
     end
@@ -180,10 +170,7 @@ describe Rbeapi::Client do
                                            password: 'test',
                                            transport: 'http',
                                            host: 'test2'
-                                          )).to eq(username: 'test2',
-                                                   password: 'test',
-                                                   transport: 'http',
-                                                   host: 'test2')
+                                          )).to eq(nil)
       expect(subject.config.get_connection('test2'))
         .to eq(username: 'test2',
                password: 'test',
@@ -216,12 +203,6 @@ describe Rbeapi::Client do
 
     it 'expects startup-configuration to be a string' do
       expect(node.startup_config).to be_kind_of(String)
-    end
-  end
-
-  describe '#enable_authentication' do
-    it 'gets the nodes startup-configuration' do
-      expect(node.enable_authentication('newpassword')).to eq('newpassword')
     end
   end
 
@@ -309,11 +290,6 @@ describe Rbeapi::Client do
                                open_timeout: 26,
                                read_timeout: 26)[0]).to include('fqdn',
                                                                 'hostname')
-    end
-
-    it 'sends commands with enablepwd set' do
-      expect(node.enable_authentication('icanttellyou')).to eq('icanttellyou')
-      expect(node.run_commands('show hostname')).to be_truthy
     end
 
     it 'expects run_commands to raise a command error' do

--- a/spec/unit/rbeapi/client_spec.rb
+++ b/spec/unit/rbeapi/client_spec.rb
@@ -48,6 +48,14 @@ describe Rbeapi::Client do
     fixture_file('test.conf')
   end
 
+  def empty_conf
+    fixture_file('empty.conf')
+  end
+
+  def yaml_conf
+    fixture_file('eapi.conf.yaml')
+  end
+
   let(:dut) do
     File.read(dut_conf)
   end
@@ -80,21 +88,26 @@ describe Rbeapi::Client do
 
   let(:test_data) do
     [
-      '[connection:veos01]',
-      '[connection:veos02]',
-      '[connection:veos03',
-      '[connection:veos04]',
-      '[connection:veos05]',
-      '[connection: localhost]',
-      'username',
-      'password',
-      'transport',
-      'host'
+      '[connection:veos01]'
     ]
   end
 
+  let(:default_entry) { "[connection:localhost]\ntransport : socket\n" }
+
   # Client class methods
   describe '#config_for' do
+    # Verify that the EAPI_CONF env variable path is used by default
+    # when the Config class is instantiated/reload-ed.
+    it 'env path to config file' do
+      # Store env path for the eapi conf file and reload the class
+      conf = fixture_dir + '/env_path.conf'
+      ENV.store('EAPI_CONF', conf)
+      subject.config.reload
+
+      # Verify env_path.conf file was loaded
+      expect(subject.config.to_s).to include('[connection:env_path]')
+    end
+
     it 'returns the configuration options for the connection' do
       expect(subject.load_config(test_conf)).to eq(nil)
       expect(subject.config_for('veos01')).to eq(veos01)
@@ -121,11 +134,21 @@ describe Rbeapi::Client do
       expect(subject.load_config(test_conf)).to eq(nil)
       expect(subject.config.to_s).to include(test_data[0])
     end
+
+    it 'loading empty config file does not fail' do
+      expect(subject.load_config(empty_conf)).to eq(nil)
+      expect(subject.config.to_s).to eq(default_entry)
+    end
+
+    it 'does not load bad config file data' do
+      expect(subject.load_config(yaml_conf)).to eq(nil)
+      expect(subject.config.to_s).to eq('')
+    end
   end
 
   describe '#read' do
     it 'read the specified filename and load it' do
-      expect(subject.load_config(dut_conf)).to eq(transport: 'socket')
+      expect(subject.load_config(dut_conf)).to eq(nil)
       expect(subject.config.read(test_conf)).to eq(nil)
       expect(subject.config.to_s).to include(test_data[0])
     end
@@ -140,8 +163,7 @@ describe Rbeapi::Client do
   describe '#reload' do
     it 'reloads the configuration file' do
       expect(subject.config.get_connection('veos01')).to eq(veos01)
-      expect(subject.config.reload(filename: [dut_conf]))
-        .to eq(transport: 'socket')
+      expect(subject.config.reload(filename: [dut_conf])).to eq(nil)
       expect(subject.config.get_connection('veos01')).to eq(nil)
       expect(subject.config.get_connection('dut')).not_to be_nil
     end
@@ -154,10 +176,7 @@ describe Rbeapi::Client do
                                            password: 'test',
                                            transport: 'http',
                                            host: 'test2'
-                                          )).to eq(username: 'test2',
-                                                   password: 'test',
-                                                   transport: 'http',
-                                                   host: 'test2')
+                                          )).to eq(nil)
       expect(subject.config.get_connection('test2'))
         .to eq(username: 'test2',
                password: 'test',


### PR DESCRIPTION
Created utils method to syslog warning messages.
Updated add_connection to return nil instead of returning connection values.
Updated tests to deal with add_connection return value change.
Added test case for bad conf file and empty conf file.
Added test case to verify EAPI_CONF path is used.
Fixes issue #82