### PR TITLE
fix speed functions

### DIFF
--- a/lib/rbeapi/api/interfaces.rb
+++ b/lib/rbeapi/api/interfaces.rb
@@ -537,7 +537,7 @@ module Rbeapi
       def set_speed(name, opts = {})
         value = opts[:value]
         enable = opts.fetch(:enable, true)
-        default = (value == "default")
+        default = (value == :default)
 
         cmds = ["interface #{name}"]
         case default
@@ -547,6 +547,7 @@ module Rbeapi
           cmd = enable ? "speed #{value}" : 'no speed'
           cmds << cmd
         end
+
         configure cmds
       end
 

--- a/lib/rbeapi/api/interfaces.rb
+++ b/lib/rbeapi/api/interfaces.rb
@@ -428,7 +428,7 @@ module Rbeapi
       # @return [Hash<Symbol, Object>] Returns the resource hash attribute.
       def parse_speed(config)
         value = config.scan(/speed (.*)/).first
-        { speed: value.nil? ? DEFAULT_SPEED : value }
+        { speed: value.nil? ? DEFAULT_SPEED : value.first }
       end
       private :parse_speed
 

--- a/spec/system/rbeapi/api/interfaces_ethernet_spec.rb
+++ b/spec/system/rbeapi/api/interfaces_ethernet_spec.rb
@@ -14,9 +14,9 @@ describe Rbeapi::Api::Interfaces do
 
   describe '#get' do
     let(:entity) do
-      { name: 'Ethernet1', type: 'ethernet', description: '', shutdown: false, load_interval: '',
-        speed: 'auto', forced: false, sflow: true, flowcontrol_send: 'off',
-        flowcontrol_receive: 'off' }
+      { name: 'Ethernet1', type: 'ethernet', description: '', shutdown: false,
+        load_interval: '', speed: 'default', sflow: true,
+        flowcontrol_send: 'off', flowcontrol_receive: 'off' }
     end
 
     before { node.config(['default interface Ethernet1']) }
@@ -89,13 +89,8 @@ describe Rbeapi::Api::Interfaces do
   describe '#set_speed' do
     before { node.config(['default interface Ethernet1']) }
 
-    it 'sets default true' do
-      expect(subject.set_speed('Ethernet1', default: true)).to be_truthy
-    end
-
     it 'sets enable true' do
-      expect(subject.set_speed('Ethernet1', default: false,
-                                            enable: true)).to be_falsy
+      expect(subject.set_speed('Ethernet1', enable: true)).to be_falsy
     end
   end
 

--- a/spec/unit/rbeapi/api/interfaces/ethernet_spec.rb
+++ b/spec/unit/rbeapi/api/interfaces/ethernet_spec.rb
@@ -24,7 +24,7 @@ describe Rbeapi::Api::EthernetInterface do
 
     let(:keys) do
       [:type, :speed, :sflow, :flowcontrol_send, :flowcontrol_receive,
-       :forced, :shutdown, :description, :name, :load_interval]
+       :shutdown, :description, :name, :load_interval]
     end
 
     it 'returns an ethernet resource as a hash' do


### PR DESCRIPTION
This commits change the behaviour of the speed functions (parse_speed and set_speed).
Before the speed setting could not be applied to an ethernet interface.