### PR TITLE
fix speed functions and add lacp port-priority functions

### DIFF
--- a/lib/rbeapi/api/interfaces.rb
+++ b/lib/rbeapi/api/interfaces.rb
@@ -537,7 +537,7 @@ module Rbeapi
       def set_speed(name, opts = {})
         value = opts[:value]
         enable = opts.fetch(:enable, true)
-        default = (value == "default")
+        default = (value == :default)
 
         cmds = ["interface #{name}"]
         case default
@@ -547,6 +547,7 @@ module Rbeapi
           cmd = enable ? "speed #{value}" : 'no speed'
           cmds << cmd
         end
+
         configure cmds
       end
 

--- a/lib/rbeapi/api/interfaces.rb
+++ b/lib/rbeapi/api/interfaces.rb
@@ -377,7 +377,7 @@ module Rbeapi
       DEFAULT_ETH_FLOWC_TX = 'off'
       DEFAULT_ETH_FLOWC_RX = 'off'
       DEFAULT_SPEED = 'default'
-      DEFAULT_LACP_PORT_PRIO = 32768
+      DEFAULT_LACP_PRIORITY = 32768
 
       ##
       # get returns the specified Ethernet interface resource hash that
@@ -394,7 +394,7 @@ module Rbeapi
       #     sflow: <boolean>,
       #     flowcontrol_send: <string>,
       #     flowcontrol_receive: <string>
-      #     lacp_port_priority: <integer>
+      #     lacp_priority: <integer>
       #   }
       #
       # @param name [String] The interface name to return a resource hash
@@ -414,7 +414,7 @@ module Rbeapi
         response.merge!(parse_sflow(config))
         response.merge!(parse_flowcontrol_send(config))
         response.merge!(parse_flowcontrol_receive(config))
-        response.merge!(parse_lacp_port_priority(config))
+        response.merge!(parse_lacp_priority(config))
         response
       end
 
@@ -489,10 +489,10 @@ module Rbeapi
       private :parse_flowcontrol_receive
 
       ##
-      # parse_lacp_port_priority scans the provided configuration block and
-      # parse the lacp port-priority value. If the interface lacp port-priority
-      # value is not configured, then this method will return the value of
-      # DEFAULT_LACP_PORT_PRIO. The hash returned is intended to be merged into
+      # parse_lacp_priority scans the provided configuration block and parse
+      # the lacp port-priority value. If the interface lacp port-priority value
+      # is not configured, then this method will return the value of
+      # DEFAULT_LACP_PRIORITY. The hash returned is intended to be merged into
       # the interface resource hash.
       #
       # @api private
@@ -500,11 +500,11 @@ module Rbeapi
       # @param config [String] The configuration block to parse.
       #
       # @return [Hash<Symbol, Object>] Returns the resource hash attribute.
-      def parse_lacp_port_priority(config)
+      def parse_lacp_priority(config)
         mdata = /lacp port-priority (\d+)$/.match(config)
-        { lacp_port_priority: mdata.nil? ? DEFAULT_LACP_PORT_PRIO : mdata[1] }
+        { lacp_priority: mdata.nil? ? DEFAULT_LACP_PRIORITY : mdata[1] }
       end
-      private :parse_lacp_port_priority
+      private :parse_lacp_priority
 
       ##
       # create overrides the create method from the BaseInterface and raises
@@ -687,10 +687,10 @@ module Rbeapi
       end
 
       ##
-      # set_lacp_port_priority configures the lacp port-priority on the
-      # interface. Setting the enable keyword to true enables the lacp
-      # port-priority on the interface and setting enable to false disables
-      # the lacp port-priority on the interface.
+      # set_lacp_priority configures the lacp port-priority on the interface.
+      # Setting the enable keyword to true enables the lacp port-priority on
+      # the interface and setting enable to false disables the lacp
+      # port-priority on the interface.
       # If the default keyword is set to true, then the lacp port-priority
       # value is defaulted using the default keyword. The default keyword takes
       # precedence over the enable keyword
@@ -710,7 +710,7 @@ module Rbeapi
       #   on the interface using the default keyword.
       #
       # @return [Boolean] Returns true if the command completed successfully.
-      def set_lacp_port_priority(name, opts = {})
+      def set_lacp_priority(name, opts = {})
         commands = command_builder('lacp port-priority', opts)
         configure_interface(name, commands)
       end

--- a/lib/rbeapi/api/interfaces.rb
+++ b/lib/rbeapi/api/interfaces.rb
@@ -428,7 +428,7 @@ module Rbeapi
       # @return [Hash<Symbol, Object>] Returns the resource hash attribute.
       def parse_speed(config)
         value = config.scan(/speed (.*)/).first
-        { speed: value.nil? ? DEFAULT_SPEED : value }
+        { speed: value.nil? ? DEFAULT_SPEED : value.first }
       end
       private :parse_speed
 

--- a/lib/rbeapi/api/interfaces.rb
+++ b/lib/rbeapi/api/interfaces.rb
@@ -377,6 +377,7 @@ module Rbeapi
       DEFAULT_ETH_FLOWC_TX = 'off'
       DEFAULT_ETH_FLOWC_RX = 'off'
       DEFAULT_SPEED = 'default'
+      DEFAULT_LACP_PORT_PRIO = 32768
 
       ##
       # get returns the specified Ethernet interface resource hash that
@@ -393,6 +394,7 @@ module Rbeapi
       #     sflow: <boolean>,
       #     flowcontrol_send: <string>,
       #     flowcontrol_receive: <string>
+      #     lacp_port_priority: <integer>
       #   }
       #
       # @param name [String] The interface name to return a resource hash
@@ -412,6 +414,7 @@ module Rbeapi
         response.merge!(parse_sflow(config))
         response.merge!(parse_flowcontrol_send(config))
         response.merge!(parse_flowcontrol_receive(config))
+        response.merge!(parse_lacp_port_priority(config))
         response
       end
 
@@ -484,6 +487,24 @@ module Rbeapi
         { flowcontrol_receive: mdata.nil? ? DEFAULT_ETH_FLOWC_RX : mdata[1] }
       end
       private :parse_flowcontrol_receive
+
+      ##
+      # parse_lacp_port_priority scans the provided configuration block and
+      # parse the lacp port-priority value. If the interface lacp port-priority
+      # value is not configured, then this method will return the value of
+      # DEFAULT_LACP_PORT_PRIO. The hash returned is intended to be merged into
+      # the interface resource hash.
+      #
+      # @api private
+      #
+      # @param config [String] The configuration block to parse.
+      #
+      # @return [Hash<Symbol, Object>] Returns the resource hash attribute.
+      def parse_lacp_port_priority(config)
+        mdata = /lacp port-priority (\d+)$/.match(config)
+        { lacp_port_priority: mdata.nil? ? DEFAULT_LACP_PORT_PRIO : mdata[1] }
+      end
+      private :parse_lacp_port_priority
 
       ##
       # create overrides the create method from the BaseInterface and raises
@@ -663,6 +684,35 @@ module Rbeapi
       # @return [Boolean] Returns true if the command completed successfully.
       def set_flowcontrol_receive(name, opts = {})
         set_flowcontrol(name, 'receive', opts)
+      end
+
+      ##
+      # set_lacp_port_priority configures the lacp port-priority on the
+      # interface. Setting the enable keyword to true enables the lacp
+      # port-priority on the interface and setting enable to false disables
+      # the lacp port-priority on the interface.
+      # If the default keyword is set to true, then the lacp port-priority
+      # value is defaulted using the default keyword. The default keyword takes
+      # precedence over the enable keyword
+      #
+      # @since eos_version 4.13.7M
+      #
+      # @param name [String] The interface name to apply the configuration
+      #   values to. The name must be the full interface identifier.
+      #
+      # @param opts [Hash] Optional keyword arguments.
+      #
+      # @option opts enable [Boolean] Enables sflow if the value is true or
+      #   disables the lacp port-priority on the interface if false. Default is
+      #   true.
+      #
+      # @option opts default [Boolean] Configures the lacp port-priority value
+      #   on the interface using the default keyword.
+      #
+      # @return [Boolean] Returns true if the command completed successfully.
+      def set_lacp_port_priority(name, opts = {})
+        commands = command_builder('lacp port-priority', opts)
+        configure_interface(name, commands)
       end
     end
 

--- a/spec/system/rbeapi/api/interfaces_ethernet_spec.rb
+++ b/spec/system/rbeapi/api/interfaces_ethernet_spec.rb
@@ -17,7 +17,7 @@ describe Rbeapi::Api::Interfaces do
       { name: 'Ethernet1', type: 'ethernet', description: '', shutdown: false,
         load_interval: '', speed: 'default', sflow: true,
         flowcontrol_send: 'off', flowcontrol_receive: 'off',
-        lacp_port_priority: '32768' }
+        lacp_priority: '32768' }
     end
 
     before { node.config(['default interface Ethernet1']) }
@@ -173,34 +173,29 @@ describe Rbeapi::Api::Interfaces do
     end
   end
 
-  describe '#set_lacp_port_priority' do
+  describe '#set_lacp_priority' do
     before do
       node.config(['interface Ethernet1', 'default lacp port-priority'])
     end
 
     it 'sets the lacp port-priority value on the interface' do
-      expect(subject.get('Ethernet1')[:lacp_port_priority]).to eq('32768')
-      expect(subject.set_lacp_port_priority('Ethernet1', value: '0'))
-        .to be_truthy
-      expect(subject.get('Ethernet1')[:lacp_port_priority]).to eq('0')
+      expect(subject.get('Ethernet1')[:lacp_priority]).to eq('32768')
+      expect(subject.set_lacp_priority('Ethernet1', value: '0')).to be_truthy
+      expect(subject.get('Ethernet1')[:lacp_priority]).to eq('0')
     end
 
     it 'negates the lacp port-priority' do
-      expect(subject.set_lacp_port_priority('Ethernet1', value: '1'))
-        .to be_truthy
-      expect(subject.get('Ethernet1')[:lacp_port_priority]).to eq('1')
-      expect(subject.set_lacp_port_priority('Ethernet1', enable: false))
-        .to be_truthy
-      expect(subject.get('Ethernet1')[:lacp_port_priority]).to eq('32768')
+      expect(subject.set_lacp_priority('Ethernet1', value: '1')).to be_truthy
+      expect(subject.get('Ethernet1')[:lacp_priority]).to eq('1')
+      expect(subject.set_lacp_priority('Ethernet1', enable: false)).to be_truthy
+      expect(subject.get('Ethernet1')[:lacp_priority]).to eq('32768')
     end
 
     it 'defaults the lacp port-priority' do
-      expect(subject.set_lacp_port_priority('Ethernet1', value: '2'))
-        .to be_truthy
-      expect(subject.get('Ethernet1')[:lacp_port_priority]).to eq('2')
-      expect(subject.set_lacp_port_priority('Ethernet1', default: true))
-        .to be_truthy
-      expect(subject.get('Ethernet1')[:lacp_port_priority]).to eq('32768')
+      expect(subject.set_lacp_priority('Ethernet1', value: '2')).to be_truthy
+      expect(subject.get('Ethernet1')[:lacp_priority]).to eq('2')
+      expect(subject.set_lacp_priority('Ethernet1', default: true)).to be_truthy
+      expect(subject.get('Ethernet1')[:lacp_priority]).to eq('32768')
     end
   end
 end

--- a/spec/system/rbeapi/api/interfaces_ethernet_spec.rb
+++ b/spec/system/rbeapi/api/interfaces_ethernet_spec.rb
@@ -16,7 +16,8 @@ describe Rbeapi::Api::Interfaces do
     let(:entity) do
       { name: 'Ethernet1', type: 'ethernet', description: '', shutdown: false,
         load_interval: '', speed: 'default', sflow: true,
-        flowcontrol_send: 'off', flowcontrol_receive: 'off' }
+        flowcontrol_send: 'off', flowcontrol_receive: 'off',
+        lacp_port_priority: '32768' }
     end
 
     before { node.config(['default interface Ethernet1']) }
@@ -169,6 +170,37 @@ describe Rbeapi::Api::Interfaces do
       expect(subject.get('Ethernet1')[:load_interval]).to eq('10')
       expect(subject.set_load_interval('Ethernet1', default: true)).to be_truthy
       expect(subject.get('Ethernet1')[:load_interval]).to eq('')
+    end
+  end
+
+  describe '#set_lacp_port_priority' do
+    before do
+      node.config(['interface Ethernet1', 'default lacp port-priority'])
+    end
+
+    it 'sets the lacp port-priority value on the interface' do
+      expect(subject.get('Ethernet1')[:lacp_port_priority]).to eq('32768')
+      expect(subject.set_lacp_port_priority('Ethernet1', value: '0'))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:lacp_port_priority]).to eq('0')
+    end
+
+    it 'negates the lacp port-priority' do
+      expect(subject.set_lacp_port_priority('Ethernet1', value: '1'))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:lacp_port_priority]).to eq('1')
+      expect(subject.set_lacp_port_priority('Ethernet1', enable: false))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:lacp_port_priority]).to eq('32768')
+    end
+
+    it 'defaults the lacp port-priority' do
+      expect(subject.set_lacp_port_priority('Ethernet1', value: '2'))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:lacp_port_priority]).to eq('2')
+      expect(subject.set_lacp_port_priority('Ethernet1', default: true))
+        .to be_truthy
+      expect(subject.get('Ethernet1')[:lacp_port_priority]).to eq('32768')
     end
   end
 end

--- a/spec/system/rbeapi/api/interfaces_ethernet_spec.rb
+++ b/spec/system/rbeapi/api/interfaces_ethernet_spec.rb
@@ -14,9 +14,9 @@ describe Rbeapi::Api::Interfaces do
 
   describe '#get' do
     let(:entity) do
-      { name: 'Ethernet1', type: 'ethernet', description: '', shutdown: false, load_interval: '',
-        speed: 'auto', forced: false, sflow: true, flowcontrol_send: 'off',
-        flowcontrol_receive: 'off' }
+      { name: 'Ethernet1', type: 'ethernet', description: '', shutdown: false,
+        load_interval: '', speed: 'default', sflow: true,
+        flowcontrol_send: 'off', flowcontrol_receive: 'off' }
     end
 
     before { node.config(['default interface Ethernet1']) }
@@ -89,13 +89,8 @@ describe Rbeapi::Api::Interfaces do
   describe '#set_speed' do
     before { node.config(['default interface Ethernet1']) }
 
-    it 'sets default true' do
-      expect(subject.set_speed('Ethernet1', default: true)).to be_truthy
-    end
-
     it 'sets enable true' do
-      expect(subject.set_speed('Ethernet1', default: false,
-                                            enable: true)).to be_falsy
+      expect(subject.set_speed('Ethernet1', enable: true)).to be_falsy
     end
   end
 

--- a/spec/unit/rbeapi/api/interfaces/ethernet_spec.rb
+++ b/spec/unit/rbeapi/api/interfaces/ethernet_spec.rb
@@ -24,7 +24,7 @@ describe Rbeapi::Api::EthernetInterface do
 
     let(:keys) do
       [:type, :speed, :sflow, :flowcontrol_send, :flowcontrol_receive,
-       :shutdown, :description, :name, :load_interval]
+       :shutdown, :description, :name, :load_interval, :lacp_port_priority]
     end
 
     it 'returns an ethernet resource as a hash' do

--- a/spec/unit/rbeapi/api/interfaces/ethernet_spec.rb
+++ b/spec/unit/rbeapi/api/interfaces/ethernet_spec.rb
@@ -24,7 +24,7 @@ describe Rbeapi::Api::EthernetInterface do
 
     let(:keys) do
       [:type, :speed, :sflow, :flowcontrol_send, :flowcontrol_receive,
-       :shutdown, :description, :name, :load_interval, :lacp_port_priority]
+       :shutdown, :description, :name, :load_interval, :lacp_priority]
     end
 
     it 'returns an ethernet resource as a hash' do

--- a/spec/unit/rbeapi/api/interfaces/ethernet_spec.rb
+++ b/spec/unit/rbeapi/api/interfaces/ethernet_spec.rb
@@ -24,7 +24,7 @@ describe Rbeapi::Api::EthernetInterface do
 
     let(:keys) do
       [:type, :speed, :sflow, :flowcontrol_send, :flowcontrol_receive,
-       :forced, :shutdown, :description, :name, :load_interval]
+       :shutdown, :description, :name, :load_interval]
     end
 
     it 'returns an ethernet resource as a hash' do


### PR DESCRIPTION
* Changes the behaviour of the speed functions (parse_speed and set_speed). Before the speed setting could not be applied to an ethernet interface.
* Adds support of lacp port-priority for ethernet interfaces