### PR TITLE
add switchport allowed vlan range capability

### DIFF
--- a/lib/rbeapi/api/switchports.rb
+++ b/lib/rbeapi/api/switchports.rb
@@ -136,12 +136,7 @@ module Rbeapi
         return { trunk_allowed_vlans: [] } unless mdata[1] != 'none'
         vlans = mdata[1].split(',')
         values = vlans.each_with_object([]) do |vlan, arry|
-          if /-/ !~ vlan
-            arry << vlan.to_i
-          else
-            range_start, range_end = vlan.split('-')
-            arry.push(*Array(range_start.to_i..range_end.to_i))
-          end
+          arry << vlan.to_s
         end
         { trunk_allowed_vlans: values }
       end
@@ -266,7 +261,7 @@ module Rbeapi
       #
       # @option opts value [Array] The list of vlan ids to configure on the
       #   switchport to be allowed. This value must be an array of valid vlan
-      #   ids.
+      #   ids or vlan ranges.
       #
       # @option opts enable [Boolean] If false then the command is
       #   negated. Default is true.
@@ -283,7 +278,7 @@ module Rbeapi
 
         if value
           fail ArgumentError, 'value must be an Array' unless value.is_a?(Array)
-          value = value.map(&:inspect).join(',')
+          value = value.map(&:inspect).join(',').tr('"', '')
         end
 
         case default
@@ -293,8 +288,7 @@ module Rbeapi
           if !enable
             cmds = 'no switchport trunk allowed vlan'
           else
-            cmds = ['switchport trunk allowed vlan none',
-                    "switchport trunk allowed vlan #{value}"]
+            cmds = ["switchport trunk allowed vlan #{value}"]
           end
         end
         configure_interface(name, cmds)

--- a/spec/system/rbeapi/api/switchports_spec.rb
+++ b/spec/system/rbeapi/api/switchports_spec.rb
@@ -191,34 +191,36 @@ describe Rbeapi::Api::Switchports do
         .to raise_error(ArgumentError)
     end
 
-    it 'sets vlan 8 and 9 to the trunk allowed vlans' do
+    it 'sets vlan 8-10 and 100 to the trunk allowed vlans' do
       node.config(['interface Ethernet1', 'switchport trunk allowed vlan none'])
       expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to be_empty
-      expect(subject.set_trunk_allowed_vlans('Ethernet1', value: [8, 9]))
+      expect(subject.set_trunk_allowed_vlans('Ethernet1', value: ['8-10', '100']))
         .to be_truthy
-      expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to eq([8, 9])
+      expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to eq(['8-10', '100'])
     end
 
     it 'negate switchport trunk allowed vlan' do
       node.config(['interface Ethernet1', 'switchport trunk allowed vlan none'])
       expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to be_empty
-      expect(subject.set_trunk_allowed_vlans('Ethernet1', value: [8, 9]))
+      expect(subject.set_trunk_allowed_vlans('Ethernet1', value: ['8-10', '100']))
         .to be_truthy
-      expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to eq([8, 9])
+      expect(subject.get('Ethernet1')[:trunk_allowed_vlans])
+        .to eq(['8-10', '100'])
       expect(subject.set_trunk_allowed_vlans('Ethernet1', enable: false))
         .to be_truthy
-      expect(subject.get('Ethernet1')[:trunk_allowed_vlans].length).to eq(4094)
+      expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to eq(['1-4094'])
     end
 
     it 'default switchport trunk allowed vlan' do
       node.config(['interface Ethernet1', 'switchport trunk allowed vlan none'])
       expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to be_empty
-      expect(subject.set_trunk_allowed_vlans('Ethernet1', value: [8, 9]))
+      expect(subject.set_trunk_allowed_vlans('Ethernet1', value: ['8-10', '100']))
         .to be_truthy
-      expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to eq([8, 9])
+      expect(subject.get('Ethernet1')[:trunk_allowed_vlans])
+        .to eq(['8-10', '100'])
       expect(subject.set_trunk_allowed_vlans('Ethernet1', default: true))
         .to be_truthy
-      expect(subject.get('Ethernet1')[:trunk_allowed_vlans].length).to eq(4094)
+      expect(subject.get('Ethernet1')[:trunk_allowed_vlans]).to eq(['1-4094'])
     end
   end
 

--- a/spec/unit/rbeapi/api/switchports/default_spec.rb
+++ b/spec/unit/rbeapi/api/switchports/default_spec.rb
@@ -195,11 +195,10 @@ describe Rbeapi::Api::Switchports do
         .to raise_error(ArgumentError)
     end
 
-    it 'sets vlan 8 and 9 to the trunk allowed vlans' do
+    it 'sets vlan 8-10 and 100 to the trunk allowed vlans' do
       expect(node).to receive(:config)
-        .with(['interface Ethernet1', 'switchport trunk allowed vlan none',
-               'switchport trunk allowed vlan 8,9'])
-      expect(subject.set_trunk_allowed_vlans('Ethernet1', value: [8, 9]))
+        .with(['interface Ethernet1', 'switchport trunk allowed vlan 8-10,100'])
+      expect(subject.set_trunk_allowed_vlans('Ethernet1', value: ['8-10','100']))
         .to be_truthy
     end
 


### PR DESCRIPTION
* Adds switchport allowed vlan range capability. Allowed vlans will be returned as they appear in the eos and can be configured in the same way as in the eos: (old: 5,6,7,9,10,15 new: 5-7,9-10,15)
* The allowed vlans array changed from int to string because a vlan range could be returned and set