### PR TITLE
fix issue #142 - multicast group parsing when not configured

### DIFF
--- a/lib/rbeapi/api/interfaces.rb
+++ b/lib/rbeapi/api/interfaces.rb
@@ -1122,11 +1122,13 @@ module Rbeapi
       # @api private
       #
       # @param config [String] The interface configuration block to extract
-      #   the vxlan multicast-group value from.
+      #   the vxlan multicast-group value from. Note the configuration line
+      #   'vxlan multicast-group decap' is excluded so the multicast group
+      #   value is correctly assigned '' when not defined.
       #
       # @return [Hash<Symbol, Object>]
       def parse_multicast_group(config)
-        mdata = /multicast-group ([^\s]+)$/.match(config)
+        mdata = /multicast-group (?!decap)([^\s]+)$/.match(config)
         { multicast_group: mdata ? mdata[1] : DEFAULT_MCAST_GRP }
       end
       private :parse_multicast_group

--- a/lib/rbeapi/api/interfaces.rb
+++ b/lib/rbeapi/api/interfaces.rb
@@ -1122,13 +1122,11 @@ module Rbeapi
       # @api private
       #
       # @param config [String] The interface configuration block to extract
-      #   the vxlan multicast-group value from. Note the configuration line
-      #   'vxlan multicast-group decap' is excluded so the multicast group
-      #   value is correctly assigned '' when not defined.
+      #   the vxlan multicast-group value from.
       #
       # @return [Hash<Symbol, Object>]
       def parse_multicast_group(config)
-        mdata = /multicast-group (?!decap)([^\s]+)$/.match(config)
+        mdata = /^\s*vxlan multicast-group ([^\s]+)$/.match(config)
         { multicast_group: mdata ? mdata[1] : DEFAULT_MCAST_GRP }
       end
       private :parse_multicast_group

--- a/spec/system/rbeapi/api/interfaces_base_spec.rb
+++ b/spec/system/rbeapi/api/interfaces_base_spec.rb
@@ -60,7 +60,7 @@ describe Rbeapi::Api::Interfaces do
 
       it 'returns the interface resource' do
         expect(subject.get('Vxlan1')).to eq(entity)
-      end     
+      end
     end
   end
 

--- a/spec/system/rbeapi/api/interfaces_base_spec.rb
+++ b/spec/system/rbeapi/api/interfaces_base_spec.rb
@@ -61,6 +61,20 @@ describe Rbeapi::Api::Interfaces do
       it 'returns the interface resource' do
         expect(subject.get('Vxlan1')).to eq(entity)
       end
+
+      let(:entity) do
+        { name: 'Vxlan1', type: 'vxlan', description: '',
+          shutdown: false, load_interval: '', source_interface: '', multicast_group: '224.0.2.0',
+          udp_port: 4789, flood_list: [], vlans: {} }
+      end
+
+      before do
+        node.config(['no interface Vxlan1', 'interface Vxlan1', 'vxlan multicast-group 224.0.2.0'])
+      end
+
+      it 'returns the interface resource with multicast group set' do
+        expect(subject.get('Vxlan1')).to eq(entity)
+      end      
     end
   end
 

--- a/spec/system/rbeapi/api/interfaces_base_spec.rb
+++ b/spec/system/rbeapi/api/interfaces_base_spec.rb
@@ -60,21 +60,7 @@ describe Rbeapi::Api::Interfaces do
 
       it 'returns the interface resource' do
         expect(subject.get('Vxlan1')).to eq(entity)
-      end
-
-      let(:entity) do
-        { name: 'Vxlan1', type: 'vxlan', description: '',
-          shutdown: false, load_interval: '', source_interface: '', multicast_group: '224.0.2.0',
-          udp_port: 4789, flood_list: [], vlans: {} }
-      end
-
-      before do
-        node.config(['no interface Vxlan1', 'interface Vxlan1', 'vxlan multicast-group 224.0.2.0'])
-      end
-
-      it 'returns the interface resource with multicast group set' do
-        expect(subject.get('Vxlan1')).to eq(entity)
-      end      
+      end     
     end
   end
 


### PR DESCRIPTION
This fixes the issue #142 by excluding the `multicast-group decap` line so the multicast group is '' when not configured.

An additional test has been added for parsing the multicast group when set.