### PR TITLE
fix parse_instances to return the default instances and add tests

### DIFF
--- a/lib/rbeapi/api/stp.rb
+++ b/lib/rbeapi/api/stp.rb
@@ -196,15 +196,18 @@ module Rbeapi
 
       ##
       # parse_instances will scan the nodes current configuration and extract
-      # the list of configured mst instances. If no instances are configured
-      # then this method will return an empty array.
+      # the list of configured mst instances. Instances 0 and 1 are defined by
+      # default in the switch config and are always returned, even if not
+      # visible in the 'spanning-tree mst configuration' config section.
       #
       # @api private
       #
       # @return [Array<String>] Returns an Array of configured stp instances.
       def parse_instances
         config = get_block('spanning-tree mst configuration')
-        config.scan(/(?<=^\s{3}instance\s)\d+/)
+        response = config.scan(/(?<=^\s{3}instance\s)\d+/)
+        response.push("0", "1").uniq!
+        response
       end
       private :parse_instances
 

--- a/spec/system/rbeapi/api/stp_instances_spec.rb
+++ b/spec/system/rbeapi/api/stp_instances_spec.rb
@@ -15,14 +15,24 @@ describe Rbeapi::Api::StpInstances do
     before do
       node.config(['spanning-tree mode mstp',
                    'spanning-tree mst configuration',
-                   'instance 1 vlans 1', 'exit'])
+                   'instance 10 vlans 100', 'exit'])
     end
 
     it 'returns the stp instance resource as a hash' do
+      expect(subject.get('10')).to be_a_kind_of(Hash)
+    end
+
+    it 'returns the default stp instance resources as a hash' do
+      expect(subject.get('0')).to be_a_kind_of(Hash)
       expect(subject.get('1')).to be_a_kind_of(Hash)
     end
 
     it 'returns the instance priority' do
+      expect(subject.get('10')).to include(:priority)
+    end
+
+    it 'returns the default instances priority' do
+      expect(subject.get('0')).to include(:priority)
       expect(subject.get('1')).to include(:priority)
     end
   end
@@ -41,38 +51,64 @@ describe Rbeapi::Api::StpInstances do
     before do
       node.config(['spanning-tree mode mstp',
                    'spanning-tree mst configuration',
-                   'instance 1 vlans 1', 'exit'])
+                   'instance 1 vlans 1',
+                   'instance 10 vlans 100', 'exit'])
     end
 
     it 'deletes the mst instance' do
+      expect(subject.get('10')).not_to be_nil
+      expect(subject.delete('10')).to be_truthy
+      expect(subject.get('10')).to be_nil
+    end
+
+    it 'does not delete the default mst instance' do
       expect(subject.get('1')).not_to be_nil
       expect(subject.delete('1')).to be_truthy
-      expect(subject.get('1')).to be_nil
+      expect(subject.get('1')).not_to be_nil
     end
   end
 
   describe '#set_priority' do
     before do
-      node.config(['default spanning-tree mst 1 priority',
+      node.config(['default spanning-tree mst 10 priority',
                    'spanning-tree mode mstp',
                    'default spanning-tree mst configuration',
                    'spanning-tree mst configuration',
-                   'instance 1 vlans 1', 'exit'])
+                   'instance 10 vlans 100', 'exit'])
     end
 
     it 'set the instance priority' do
+      expect(subject.get('10')[:priority]).to eq('32768')
+      expect(subject.set_priority('10', value: '16384')).to be_truthy
+      expect(subject.get('10')[:priority]).to eq('16384')
+    end
+
+    it 'set the default instance priority' do
       expect(subject.get('1')[:priority]).to eq('32768')
       expect(subject.set_priority('1', value: '4096')).to be_truthy
       expect(subject.get('1')[:priority]).to eq('4096')
     end
 
     it 'set the instance priority to default' do
+      expect(subject.set_priority('10', value: '16384',
+                                       default: true)).to be_truthy
+      expect(subject.get('10')[:priority]).to eq('32768')
+    end
+
+    it 'set the default instance priority to default' do
       expect(subject.set_priority('1', value: '4096',
                                        default: true)).to be_truthy
       expect(subject.get('1')[:priority]).to eq('32768')
     end
 
     it 'set the instance priority to enable false' do
+      expect(subject.set_priority('10', value: '16384',
+                                       default: false,
+                                       enable: false)).to be_truthy
+      expect(subject.get('10')[:priority]).to eq('32768')
+    end
+
+    it 'set the default instance priority to enable false' do
       expect(subject.set_priority('1', value: '4096',
                                        default: false,
                                        enable: false)).to be_truthy
@@ -80,6 +116,13 @@ describe Rbeapi::Api::StpInstances do
     end
 
     it 'set the instance priority to enable true' do
+      expect(subject.set_priority('10', value: '16384',
+                                       default: false,
+                                       enable: true)).to be_truthy
+      expect(subject.get('10')[:priority]).to eq('16384')
+    end
+
+    it 'set the default instance priority to enable true' do
       expect(subject.set_priority('1', value: '4096',
                                        default: false,
                                        enable: true)).to be_truthy

--- a/spec/system/rbeapi/api/stp_instances_spec.rb
+++ b/spec/system/rbeapi/api/stp_instances_spec.rb
@@ -71,6 +71,7 @@ describe Rbeapi::Api::StpInstances do
   describe '#set_priority' do
     before do
       node.config(['default spanning-tree mst 10 priority',
+                   'no spanning-tree mst 1 priority',
                    'spanning-tree mode mstp',
                    'default spanning-tree mst configuration',
                    'spanning-tree mst configuration',


### PR DESCRIPTION
This fixes the parse_instances function to always return the MST instances 0 and 1 because their priority is defined by default in EOS. The MST instance 0 never shows up in the config section "spanning-tree mst configuration" and the MST instance 1 can show up if configured so. 
Some additional tests are added to test the default mst instances and their priorities.

Example config which would can't be parsed without this fix:
`switch#show run all | s spanning-tree mst`
`spanning-tree mode mstp`
`no spanning-tree mst pvst border`
`spanning-tree mst 0 priority 8192`
`spanning-tree mst 1 priority 32768`
`!`
`spanning-tree mst configuration`
`   no name`
`   revision 0`
`switch#`