### PR TITLE
Ensure get_config, running_config, and startup_config return sane output

### DIFF
--- a/lib/rbeapi/client.rb
+++ b/lib/rbeapi/client.rb
@@ -515,7 +515,6 @@ module Rbeapi
           result = run_commands("show #{config} #{params}", encoding: 'text')
         rescue Rbeapi::Eapilib::CommandError => error
           if ( error.to_s =~ /show (running|startup)-config/ )
-            #result = [{"output"=>""}]
             return nil
           else
             raise error

--- a/lib/rbeapi/client.rb
+++ b/lib/rbeapi/client.rb
@@ -506,7 +506,8 @@ module Rbeapi
       #     interfaces  Filter config to include only the given interfaces
       #     section     Display sections containing matching commands
       #
-      # @return [String] The specified configuration as text.
+      # @return [String] The specified configuration as text or nil if no
+      #                  config is found.
       def get_config(opts = {})
         config = opts.fetch(:config, 'running-config')
         params = opts.fetch(:params, '')

--- a/lib/rbeapi/client.rb
+++ b/lib/rbeapi/client.rb
@@ -511,7 +511,16 @@ module Rbeapi
         config = opts.fetch(:config, 'running-config')
         params = opts.fetch(:params, '')
         as_string = opts.fetch(:as_string, false)
-        result = run_commands("show #{config} #{params}", encoding: 'text')
+        begin
+          result = run_commands("show #{config} #{params}", encoding: 'text')
+        rescue Rbeapi::Eapilib::CommandError => error
+          if ( error.to_s =~ /show (running|startup)-config/ )
+            #result = [{"output"=>""}]
+            return nil
+          else
+            raise error
+          end
+        end
         return result.first['output'].strip.split("\n") unless as_string
         result.first['output'].strip
       end

--- a/spec/unit/rbeapi/client_spec.rb
+++ b/spec/unit/rbeapi/client_spec.rb
@@ -209,4 +209,38 @@ describe Rbeapi::Client do
                host: 'test2')
     end
   end
+
+  describe '#get_config' do
+    def startup_config
+      "! Command: show running-config\n! device: jere-debug-agent1 (vEOS, EOS-4.14.9.1M)\n!\n! boot system flash:/vEOS-4.14.9.1M.swi\n!\nip routing vrf MGMT\n!\nmanagement api http-commands\n   no protocol https\n   protocol unix-socket\n   no shutdown\n   vrf MGMT\n      no shutdown\n!\nmanagement ssh\n   vrf MGMT\n      no shutdown\n!\n!\nend\n"
+    end
+
+    def startup_config_response
+      [{"output"=>startup_config}]
+    end
+
+    let(:node) do
+      subject.config.read(fixture_file('dut.conf'))
+      subject.connect_to('dut')
+    end
+
+    before(:each) do
+      allow(node).to receive(:run_commands) { startup_config_response }
+    end
+
+    it 'with no arguments returns the startup-config' do
+      expect(node.get_config()).to eq(startup_config.strip.split("\n"))
+    end
+
+    it 'with no arguments and an empty startup-config returns the startup-config' do
+      allow(node).to receive(:run_commands) { [{"output"=>""}] }
+      expect(node.get_config()).to eq([])
+    end
+
+    it 'with no arguments and no startup-config returns nil' do
+      msg = "CLI command 2 of 2 'show startup-config' failed: could not run command"
+      allow(node).to receive(:run_commands).and_raise(Rbeapi::Eapilib::CommandError.new(msg, 1000))
+      expect(node.get_config()).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
- Fixes #127.  Returns nil when the requested config does not exist.
- An empty config will return an empty string ('').
- Any other command error will raise CommandError.