### PR TITLE
add support for multi/single-line prefix list output

### DIFF
--- a/lib/rbeapi/api/prefixlists.rb
+++ b/lib/rbeapi/api/prefixlists.rb
@@ -68,17 +68,21 @@ module Rbeapi
       #   If the prefix list is not found, a nil object is returned.
       def get(name)
         return nil unless config =~ /ip prefix-list #{name}/
+
         # single-line prefix list
         if config =~ /ip prefix-list #{name}\sseq/
-          entries = config.scan(/^(?:ip prefix-list #{name} seq\s)(\d+)\s(permit|deny)\s(.+)$/)
+          entries = config.scan(/^(?:ip\sprefix-list\s#{name}\sseq\s)(\d+)\s
+                                (permit|deny)\s(.+)$/x)
         # or multi-line
         else
           prefix_list = get_block("ip prefix-list #{name}")
-          entries = prefix_list.scan(/^\s{3}(?:seq\s)(\d+)\s(permit|deny)\s(.+)$/)
+          entries = prefix_list.scan(/^\s+(?:seq\s)(\d+)\s
+                                     (permit|deny)\s(.+)$/x)
         end
 
         entries.each_with_object([]) do |entry, arry|
-          arry << { 'seq' => entry[0], 'action' => entry[1],
+          arry << { 'seq' => entry[0],
+                    'action' => entry[1],
                     'prefix' => entry[2] }
         end
       end
@@ -130,7 +134,7 @@ module Rbeapi
       end
 
       ##
-      # create will create a new ip prefix-list with designated name.
+      # Creates a new ip prefix-list with the designated name.
       #
       # @param name [String] The name of the ip prefix-list.
       #
@@ -140,7 +144,7 @@ module Rbeapi
       end
 
       ##
-      # add_rule will create an ip prefix-list with the designated name,
+      # Creates an ip prefix-list with the designated name,
       #   seqno, action and prefix.
       #
       # @param name [String] The name of the ip prefix-list.
@@ -160,7 +164,7 @@ module Rbeapi
       end
 
       ##
-      # delete will remove the designated prefix-list.
+      # Removes the designated prefix-list.
       #
       # @param name [String] The name of the ip prefix-list.
       #

--- a/spec/system/rbeapi/api/prefixlists_spec.rb
+++ b/spec/system/rbeapi/api/prefixlists_spec.rb
@@ -45,11 +45,10 @@ describe Rbeapi::Api::Prefixlists do
   describe '#get' do
     before do
       node.config(['no ip prefix-list test1',
-                   'ip prefix-list test1',
-                   'seq 10 permit 1.2.3.0/24',
-                   'seq 20 permit 2.3.4.0/24 le 30',
-                   'seq 30 deny 3.4.5.0/24 ge 26 le 30',
-                   'permit 5.6.7.16/28 eq 29'])
+                   'ip prefix-list test1 seq 10 permit 1.2.3.0/24',
+                   'ip prefix-list test1 seq 20 permit 2.3.4.0/24 le 30',
+                   'ip prefix-list test1 seq 30 deny 3.4.5.0/24 ge 26 le 30',
+                   'ip prefix-list test1 permit 5.6.7.16/28 eq 29'])
     end
 
     let(:prefixlist) { subject.get('test1') }
@@ -107,17 +106,14 @@ describe Rbeapi::Api::Prefixlists do
 
     before do
       node.config(del_pref_lists + 
-                  ['ip prefix-list test1',
-                  'seq 10 permit 1.2.3.0/24',
-                  'seq 20 permit 2.3.4.0/24 le 30',
-                  'seq 30 deny 3.4.5.0/24 ge 26 le 30',
-                  'permit 5.6.7.8/28',
-                  'ip prefix-list test2',
-                  'seq 10 permit 10.11.0.0/16',
-                  'seq 20 permit 10.12.0.0/16 le 24',
-                  'ip prefix-list test3'])
+                  ['ip prefix-list test1 seq 10 permit 1.2.3.0/24',
+                  'ip prefix-list test1 seq 20 permit 2.3.4.0/24 le 30',
+                  'ip prefix-list test1 seq 30 deny 3.4.5.0/24 ge 26 le 30',
+                  'ip prefix-list test1 permit 5.6.7.8/28',
+                  'ip prefix-list test2 seq 10 permit 10.11.0.0/16',
+                  'ip prefix-list test2 seq 20 permit 10.12.0.0/16 le 24',
+                  'ip prefix-list test3 permit 10.13.0.0/16'])
     end
-
     let(:prefixlists) { subject.getall }
 
     it 'returns the collection as hash' do
@@ -129,7 +125,7 @@ describe Rbeapi::Api::Prefixlists do
     end
 
     it 'has three prefix lists' do
-       expect(prefixlists.size).to eq(3)
+      expect(prefixlists.size).to eq(3)
     end
   end
 

--- a/spec/system/rbeapi/api/prefixlists_spec.rb
+++ b/spec/system/rbeapi/api/prefixlists_spec.rb
@@ -45,10 +45,10 @@ describe Rbeapi::Api::Prefixlists do
   describe '#get' do
     before do
       node.config(['no ip prefix-list test1',
-                   'ip prefix-list test1 seq 10 permit 1.2.3.0/24',
-                   'ip prefix-list test1 seq 20 permit 2.3.4.0/24 le 30',
-                   'ip prefix-list test1 seq 30 deny 3.4.5.0/24 ge 26 le 30',
-                   'ip prefix-list test1 permit 5.6.7.16/28 eq 29'])
+                   'ip prefix-list test1 seq 10 permit 10.10.1.0/24',
+                   'ip prefix-list test1 seq 20 permit 10.20.1.0/24 le 30',
+                   'ip prefix-list test1 seq 30 deny 10.30.1.0/24 ge 26 le 30',
+                   'ip prefix-list test1 permit 10.40.1.16/28 eq 29'])
     end
 
     let(:prefixlist) { subject.get('test1') }
@@ -74,22 +74,22 @@ describe Rbeapi::Api::Prefixlists do
         {
           'seq' => '10',
           'action' => 'permit',
-          'prefix' => '1.2.3.0/24'
+          'prefix' => '10.10.1.0/24'
         },
         {
           'seq' => '20',
           'action' => 'permit',
-          'prefix' => '2.3.4.0/24 le 30'
+          'prefix' => '10.20.1.0/24 le 30'
         },
         {
           'seq' => '30',
           'action' => 'deny',
-          'prefix' => '3.4.5.0/24 ge 26 le 30'
+          'prefix' => '10.30.1.0/24 ge 26 le 30'
         },
         {
           'seq' => '40',
           'action' => 'permit',
-          'prefix' => '5.6.7.16/28 eq 29'
+          'prefix' => '10.40.1.16/28 eq 29'
         }
       ]
     end
@@ -106,10 +106,10 @@ describe Rbeapi::Api::Prefixlists do
 
     before do
       node.config(del_pref_lists + 
-                  ['ip prefix-list test1 seq 10 permit 1.2.3.0/24',
-                  'ip prefix-list test1 seq 20 permit 2.3.4.0/24 le 30',
-                  'ip prefix-list test1 seq 30 deny 3.4.5.0/24 ge 26 le 30',
-                  'ip prefix-list test1 permit 5.6.7.8/28',
+                  ['ip prefix-list test1 seq 10 permit 10.10.1.0/24',
+                  'ip prefix-list test1 seq 20 permit 10.20.1.0/24 le 30',
+                  'ip prefix-list test1 seq 30 deny 10.30.1.0/24 ge 26 le 30',
+                  'ip prefix-list test1 permit 10.40.1.8/28',
                   'ip prefix-list test2 seq 10 permit 10.11.0.0/16',
                   'ip prefix-list test2 seq 20 permit 10.12.0.0/16 le 24',
                   'ip prefix-list test3 permit 10.13.0.0/16'])
@@ -145,25 +145,26 @@ describe Rbeapi::Api::Prefixlists do
   describe '#add_rule' do
     before do
       node.config(['no ip prefix-list test5',
-                    'ip prefix-list test5'])
+                   'no ip prefix-list test6',
+                   'ip prefix-list test5'])
     end
 
     it 'adds rule to an existing prefix list' do
       expect(subject.get('test5')).to eq([])
-      expect(subject.add_rule('test5', 'permit', '1.1.1.0/24')).to be_truthy
+      expect(subject.add_rule('test5', 'permit', '10.50.1.0/24')).to be_truthy
       expect(subject.get('test5')).to eq([{
                                         "seq" => "10",
                                         "action" => "permit",
-                                        "prefix" => "1.1.1.0/24"}])
+                                        "prefix" => "10.50.1.0/24"}])
     end
 
     it 'adds rule to a non-existent prefix list' do
       expect(subject.get('test6')).to eq(nil)
-      expect(subject.add_rule('test6', 'deny', '2.2.2.0/24')).to be_truthy
+      expect(subject.add_rule('test6', 'deny', '10.60.1.0/24')).to be_truthy
       expect(subject.get('test6')).to eq([{
                                       "seq" => "10",
                                       "action" => "deny",
-                                      "prefix" => "2.2.2.0/24"}])
+                                      "prefix" => "10.60.1.0/24"}])
     end
   end
 
@@ -172,10 +173,10 @@ describe Rbeapi::Api::Prefixlists do
       node.config(['no ip prefix-list test7',
                   'no ip prefix-list test8',
                   'ip prefix-list test7',
-                  'seq 10 permit 7.7.0.0/16',
+                  'seq 10 permit 10.70.0.0/16',
                   'ip prefix-list test8',
-                  'seq 10 permit 8.8.0.0/16',
-                  'deny 9.9.0.0/16 le 24'])
+                  'seq 10 permit 10.80.0.0/16',
+                  'deny 10.82.0.0/16 le 24'])
     end
 
     it 'delets a prefix list' do

--- a/spec/unit/rbeapi/api/prefixlists/default_spec.rb
+++ b/spec/unit/rbeapi/api/prefixlists/default_spec.rb
@@ -131,7 +131,14 @@ describe Rbeapi::Api::Prefixlists do
             "prefix" => "10.12.0.0/16 le 24"
           }
         ],
-        "test3" => []
+        "test3" => [],
+        "test4" => [
+          {
+            "seq" => "10",
+            "action" => "permit",
+            "prefix" => "10.14.0.0/16 le 20"
+          }
+        ]
       }
     end
 
@@ -143,8 +150,8 @@ describe Rbeapi::Api::Prefixlists do
       expect(resource).to be_a_kind_of(Hash)
     end
 
-    it 'has three prefix lists' do
-      expect(resource.size).to eq(3)
+    it 'has four prefix lists' do
+      expect(resource.size).to eq(4)
     end
   end
 

--- a/spec/unit/rbeapi/api/prefixlists/default_spec.rb
+++ b/spec/unit/rbeapi/api/prefixlists/default_spec.rb
@@ -57,17 +57,17 @@ describe Rbeapi::Api::Prefixlists do
         [{
           'seq' => '10',
           'action' => 'permit',
-          'prefix' => '1.2.3.0/24'
+          'prefix' => '10.10.1.0/24'
         },
         {
           'seq' => '20',
           'action' => 'permit',
-          'prefix' => '2.3.4.0/24 le 30'
+          'prefix' => '10.20.1.0/24 le 30'
         },
         {
           'seq' => '30',
           'action' => 'permit',
-          'prefix' => '3.4.5.0/24 ge 26 le 30'
+          'prefix' => '10.30.1.0/24 ge 26 le 30'
         }]
     end
 
@@ -106,17 +106,17 @@ describe Rbeapi::Api::Prefixlists do
           {
             "seq" => "10",
             "action" => "permit",
-            "prefix" => "1.2.3.0/24"
+            "prefix" => "10.10.1.0/24"
           },
           {
             "seq" => "20",
             "action" => "permit",
-            "prefix" => "2.3.4.0/24 le 30"
+            "prefix" => "10.20.1.0/24 le 30"
           },
           {
             "seq" => "30",
             "action" => "permit",
-            "prefix" => "3.4.5.0/24 ge 26 le 30"
+            "prefix" => "10.30.1.0/24 ge 26 le 30"
           }
         ],
         "test2" => [
@@ -169,28 +169,28 @@ describe Rbeapi::Api::Prefixlists do
 
   describe '#add_rule' do
     it 'adds rule to existing prefix list' do
-      expect(node).to receive(:config).with('ip prefix-list test1 seq 25 permit 9.8.7.0/24')
-      expect(subject.add_rule('test1', 'permit','9.8.7.0/24', '25')).to be_truthy
+      expect(node).to receive(:config).with('ip prefix-list test1 seq 25 permit 10.25.1.0/24')
+      expect(subject.add_rule('test1', 'permit','10.25.1.0/24', '25')).to be_truthy
     end
 
     it 'adds rule to existing prefix list w/o seq' do
-      expect(node).to receive(:config).with('ip prefix-list test1 permit 8.7.6.0/24')
-      expect(subject.add_rule('test1', 'permit', '8.7.6.0/24')).to be_truthy
+      expect(node).to receive(:config).with('ip prefix-list test1 permit 10.25.2.0/24')
+      expect(subject.add_rule('test1', 'permit', '10.25.2.0/24')).to be_truthy
     end
 
     it 'adds rule to non-existing prefix list' do
-      expect(node).to receive(:config).with('ip prefix-list plist2 seq 10 permit 6.5.4.128/25')
-      expect(subject.add_rule('plist2', 'permit', '6.5.4.128/25', '10')).to be_truthy
+      expect(node).to receive(:config).with('ip prefix-list plist2 seq 10 permit 10.25.3.128/25')
+      expect(subject.add_rule('plist2', 'permit', '10.25.3.128/25', '10')).to be_truthy
     end
 
     it 'adds rule to non-existing prefix list w/o seq' do
-      expect(node).to receive(:config).with('ip prefix-list plist2 deny 5.4.3.0/25')
-      expect(subject.add_rule('plist2', 'deny', '5.4.3.0/25')).to be_truthy
+      expect(node).to receive(:config).with('ip prefix-list plist2 deny 10.25.10.0/25')
+      expect(subject.add_rule('plist2', 'deny', '10.25.10.0/25')).to be_truthy
     end
 
     it 'overwrites existing rule' do
-      expect(node).to receive(:config).with('ip prefix-list test1 seq 20 permit 2.3.5.0/24 le 28')
-      expect(subject.add_rule('test1', 'permit', '2.3.5.0/24 le 28', '20')).to be_truthy
+      expect(node).to receive(:config).with('ip prefix-list test1 seq 20 permit 10.25.20.0/24 le 28')
+      expect(subject.add_rule('test1', 'permit', '10.25.20.0/24 le 28', '20')).to be_truthy
     end
   end
 

--- a/spec/unit/rbeapi/api/prefixlists/fixture_prefixlists.text
+++ b/spec/unit/rbeapi/api/prefixlists/fixture_prefixlists.text
@@ -1,7 +1,7 @@
 ip prefix-list test1
-   seq 10 permit 1.2.3.0/24
-   seq 20 permit 2.3.4.0/24 le 30
-   seq 30 permit 3.4.5.0/24 ge 26 le 30
+   seq 10 permit 10.10.1.0/24
+   seq 20 permit 10.20.1.0/24 le 30
+   seq 30 permit 10.30.1.0/24 ge 26 le 30
 !
 ip prefix-list test2
    seq 10 permit 10.11.0.0/16

--- a/spec/unit/rbeapi/api/prefixlists/fixture_prefixlists.text
+++ b/spec/unit/rbeapi/api/prefixlists/fixture_prefixlists.text
@@ -9,3 +9,5 @@ ip prefix-list test2
 !
 ip prefix-list test3
 !
+ip prefix-list test4 seq 10 permit 10.14.0.0/16 le 20
+!

--- a/spec/unit/rbeapi/api/prefixlists/fixture_prefixlists.text
+++ b/spec/unit/rbeapi/api/prefixlists/fixture_prefixlists.text
@@ -11,3 +11,6 @@ ip prefix-list test3
 !
 ip prefix-list test4 seq 10 permit 10.14.0.0/16 le 20
 !
+ip prefix-list test5 seq 10 permit 10.50.1.0/24
+ip prefix-list test5 seq 20 permit 10.50.2.0/24
+!


### PR DESCRIPTION
	- update 'get' and 'getall' to be able to handle multi/single-line
	- add single-line prefix list to unit test fixture
	- update system spec tests to use also single-line