### PR TITLE
added support for autostate

### DIFF
--- a/spec/system/rbeapi/api/interfaces_vlan_spec.rb
+++ b/spec/system/rbeapi/api/interfaces_vlan_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+require 'rbeapi/client'
+require 'rbeapi/api/interfaces'
+
+describe Rbeapi::Api::Interfaces do
+  subject { described_class.new(node) }
+
+  let(:node) do
+    Rbeapi::Client.config.read(fixture_file('dut.conf'))
+    Rbeapi::Client.connect_to('dut')
+  end
+
+  describe '#get' do
+    let(:entity) do
+      { name: 'Vlan1', type: 'vlan', description: '', shutdown: false, autostate: :true, load_interval: '' }
+    end
+
+    before { node.config(['no interface Vlan1', 'interface Vlan1']) }
+
+    it 'returns the interface resource' do
+      expect(subject.get('Vlan1')).to eq(entity)
+    end
+  end
+
+  describe '#getall' do
+    before { node.config(['no interface Vlan1', 'interface Vlan1']) }
+
+    it 'returns the interface collection' do
+      expect(subject.getall).to include('Vlan1')
+    end
+
+    it 'returns a hash collection' do
+      expect(subject.getall).to be_a_kind_of(Hash)
+    end
+  end
+
+  describe '#create' do
+    before { node.config('no interface Vlan1') }
+
+    it 'creates a new interface resource' do
+      expect(subject.create('Vlan1')).to be_truthy
+      expect(subject.get('Vlan1')).not_to be_nil
+    end
+  end
+
+  describe '#delete' do
+    before { node.config(['interface Vlan1']) }
+
+    it 'deletes a vlan interface resource' do
+      expect(subject.get('Vlan1')).not_to be_nil
+      expect(subject.delete('Vlan1')).to be_truthy
+      expect(subject.get('Vlan1')).to be_nil
+    end
+  end
+
+  describe '#default' do
+    before { node.config(['interface Vlan1', 'shutdown']) }
+
+    it 'sets Vlan1 to default' do
+      expect(subject.get('Vlan1')[:shutdown]).to be_truthy
+      expect(subject.default('Vlan1')).to be_truthy
+      expect(subject.get('Vlan1')[:shutdown]).to be_falsy
+    end
+  end
+
+  describe '#set_autostate' do
+
+    it 'sets the autostate value to true' do
+      node.config(['interface Vlan1', 'no autostate'])
+      expect(subject.get('Vlan1')[:autostate]).to eq(:false)
+      expect(subject.set_autostate('Vlan1', value: :true)).to be_truthy
+      expect(subject.get('Vlan1')[:autostate]).to eq(:true)
+    end
+
+    it 'sets the autostate value to false' do
+      node.config(['interface Vlan1', 'autostate'])
+      expect(subject.get('Vlan1')[:autostate]).to be_truthy
+      expect(subject.set_autostate('Vlan1', value: :false)).to be_truthy
+      expect(subject.get('Vlan1')[:autostate]).to eq(:false)
+    end
+
+    it 'manages autostate default' do
+      node.config(['interface Vlan1', 'no autostate'])
+      expect(subject.get('Vlan1')[:autostate]).to eq(:false)
+      expect(subject.set_autostate('Vlan1', default: :true)).to be_truthy
+      expect(subject.get('Vlan1')[:autostate]).to eq(:true)
+    end
+  end
+end

--- a/spec/unit/rbeapi/api/interfaces/fixture_interfaces.text
+++ b/spec/unit/rbeapi/api/interfaces/fixture_interfaces.text
@@ -217,3 +217,71 @@ interface Port-Channel1
    mlag 1
    spanning-tree portfast
 !
+interface Vlan1
+   no description
+   no shutdown
+   default load-interval
+   mtu 1500
+   logging event link-status use-global
+   autostate
+   snmp trap link-status
+   no ip proxy-arp
+   no ip local-proxy-arp
+   no ip address
+   no ip verify unicast
+   default arp timeout 14400
+   default ipv6 nd cache expire 14400
+   bfd interval 300 min_rx 300 multiplier 3
+   no bfd echo
+   default ip dhcp smart-relay
+   no ip helper-address
+   no ipv6 dhcp relay destination
+   ip dhcp relay information option circuit-id Vlan1
+   no ip igmp
+   ip igmp version 3
+   ip igmp last-member-query-count 2
+   ip igmp last-member-query-interval 10
+   ip igmp query-max-response-time 100
+   ip igmp query-interval 125
+   ip igmp startup-query-count 2
+   ip igmp startup-query-interval 310
+   ip igmp router-alert optional connected
+   no ip igmp host-proxy
+   no ipv6 enable
+   no ipv6 address
+   no ipv6 verify unicast
+   no ipv6 nd ra suppress
+   ipv6 nd ra interval msec 200000
+   ipv6 nd ra lifetime 1800
+   no ipv6 nd ra mtu suppress
+   no ipv6 nd managed-config-flag
+   no ipv6 nd other-config-flag
+   ipv6 nd reachable-time 0
+   ipv6 nd router-preference medium
+   ipv6 nd ra dns-servers lifetime 300
+   ipv6 nd ra dns-suffixes lifetime 300
+   ipv6 nd ra hop-limit 64
+   no ip multicast static
+   ip mfib fastdrop
+   default ntp serve
+   default ip ospf bfd
+   ip ospf cost 10
+   ip ospf dead-interval 40
+   ip ospf hello-interval 10
+   ip ospf priority 1
+   ip ospf retransmit-interval 5
+   no ip ospf shutdown
+   ip ospf transmit-delay 1
+   no ip ospf authentication
+   no ip ospf mtu-ignore
+   no ip pim sparse-mode
+   no ip pim bidirectional
+   no ip pim border-router
+   ip pim query-interval 30
+   ip pim query-count 3.5
+   ip pim join-prune-interval 60
+   ip pim dr-priority 1
+   no ip pim neighbor-filter
+   default ip pim bfd-instance
+   no ip pim bsr-border
+!

--- a/spec/unit/rbeapi/api/interfaces/vlan_spec.rb
+++ b/spec/unit/rbeapi/api/interfaces/vlan_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+require 'rbeapi/api/interfaces'
+
+include FixtureHelpers
+
+describe Rbeapi::Api::VlanInterface do
+  subject { described_class.new(node) }
+
+  let(:node) { double('node') }
+
+  def interfaces
+    interfaces = Fixtures[:interfaces]
+    return interfaces if interfaces
+    fixture('interfaces', format: :text, dir: File.dirname(__FILE__))
+  end
+
+  before :each do
+    allow(subject.node).to receive(:running_config).and_return(interfaces)
+  end
+
+  describe '#get' do
+    let(:resource) { subject.get('Vlan1') }
+
+    let(:keys) do
+      [:type, :shutdown, :load_interval, :description, :name, :autostate]
+    end
+
+    it 'returns the resource as a hash' do
+      expect(resource).to be_a_kind_of(Hash)
+    end
+
+    it 'returns an interface type of vlan' do
+      expect(resource[:type]).to eq('vlan')
+    end
+
+    it 'has all keys' do
+      expect(resource.keys).to match_array(keys)
+    end
+  end
+
+  describe '#create' do
+    it 'creates the interface in the config' do
+      expect(node).to receive(:config).with('interface Vlan1')
+      expect(subject.create('Vlan1')).to be_truthy
+    end
+  end
+
+  describe '#delete' do
+    it 'deletes the interface in the config' do
+      expect(node).to receive(:config).with('no interface Vlan1')
+      expect(subject.delete('Vlan1')).to be_truthy
+    end
+  end
+
+  describe '#default' do
+    it 'defaults the interface config' do
+      expect(node).to receive(:config).with('default interface Vlan1')
+      expect(subject.default('Vlan1')).to be_truthy
+    end
+  end
+
+  describe '#set_autostate' do
+    it 'sets the autostate' do
+      commands = ['interface Vlan1', 'autostate']
+      opts = { value: :true }
+      expect(node).to receive(:config).with(commands)
+      expect(subject.set_autostate('Vlan1', opts)).to be_truthy
+    end
+
+  end
+end


### PR DESCRIPTION
This patch implements the autostate function for vlans, which is necessary for e.g. MLAG configuration.