### PR TITLE
(maint) Enhance configure exception info

### DIFF
--- a/lib/rbeapi/api.rb
+++ b/lib/rbeapi/api.rb
@@ -128,8 +128,9 @@ module Rbeapi
       def configure(commands)
         @node.config(commands)
         return true
-      rescue Rbeapi::Eapilib::CommandError, Rbeapi::Eapilib::ConnectionError
-        return false
+      rescue Rbeapi::Eapilib::CommandError,
+             Rbeapi::Eapilib::ConnectionError => e
+        return false, e
       end
 
       ##

--- a/lib/rbeapi/eapilib.rb
+++ b/lib/rbeapi/eapilib.rb
@@ -283,6 +283,10 @@ module Rbeapi
           if decoded.include?('error')
             code = decoded['error']['code']
             msg = decoded['error']['message']
+            if decoded['error'].key?('data')
+              msg = msg + "\n" +
+                    decoded['error']['data'][-1]['errors'].join(' ')
+            end
             raise CommandError.new(msg, code)
           end
         rescue Timeout::Error

--- a/spec/system/rbeapi/api/interfaces_ethernet_spec.rb
+++ b/spec/system/rbeapi/api/interfaces_ethernet_spec.rb
@@ -124,7 +124,7 @@ describe Rbeapi::Api::Interfaces do
 
     it 'sets enable true' do
       expect(subject.set_speed('Ethernet1', default: false,
-                                            enable: true)).to be_falsy
+                                            enable: true)).to include(false)
     end
   end
 


### PR DESCRIPTION
Previously configure would only return false on failure, which is not overly useful.  This commit includes the exception itself

Additionally CommandError now includes the err from the device.

This makes output in higher level tools far more actionable:

```
Notice: /Stage[main]/Main/Ntp_server[0.us.pool.ntp.org]/source_interface: defined 'source_interface' as 'Management1'
Notice: /Stage[main]/Main/Ntp_server[0.us.pool.ntp.org]/vrf: defined 'vrf' as 'test'
Error: CLI command 3 of 3 'ntp server vrf test 0.us.pool.ntp.org prefer source Management1 ' failed: could not run command
All NTP servers must be in the same VRF. Please remove time servers from VRF default before continuing. 
```

