### PR TITLE
Update stp.rb

### DIFF
--- a/lib/rbeapi/api/stp.rb
+++ b/lib/rbeapi/api/stp.rb
@@ -81,7 +81,7 @@ module Rbeapi
       #
       # @return [Hash<Symbol, Object>] Resource hash attribute.
       def parse_mode
-        mdata = /(?<=spanning-tree\smode\s)(\w+)$/.match(config)
+        mdata = /(?<=spanning-tree\smode\s)([-\w]+)$/.match(config)
         { mode: mdata[1] }
       end
 


### PR DESCRIPTION
Regex match doesn't work when using spanning tree mode rapid-pvst. Match is wrong.
Puppet errors with Nil class. Fix is to match hyphen.