### PR TITLE
add eAPI versioning option

### DIFF
--- a/lib/rbeapi/eapilib.rb
+++ b/lib/rbeapi/eapilib.rb
@@ -207,8 +207,9 @@ module Rbeapi
       def request(commands, opts = {})
         id = opts.fetch(:reqid, object_id)
         format = opts.fetch(:format, 'json')
+        version = opts.fetch(:version, 1)
         cmds = [*commands]
-        params = { 'version' => 1, 'cmds' => cmds, 'format' => format }
+        params = { 'version' => version, 'cmds' => cmds, 'format' => format }
         { 'jsonrpc' => '2.0', 'method' => 'runCmds',
           'params' => params, 'id' => id }
       end


### PR DESCRIPTION

### Usage Sample

Add option `version`, default is `1`.

```ruby
require 'rbeapi/client

node = Rbeapi::Client.connect_to("192.0.2.1")
node.enable('show ipv6 bgp summary', 'version': 'latest')
```